### PR TITLE
fix: 온보딩 모달 배경 포커스 격리

### DIFF
--- a/docs/superpowers/plans/2026-04-28-aria-hidden-focus-isolation.md
+++ b/docs/superpowers/plans/2026-04-28-aria-hidden-focus-isolation.md
@@ -1,0 +1,151 @@
+# ARIA Hidden Focus Isolation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent onboarding from leaving focusable page controls exposed behind the modal tour without using `aria-hidden` on those controls.
+
+**Architecture:** Keep the existing custom tour overlay and isolate only the background app surface while the tour dialog is open. Use the native `inert` attribute on the background section, not `aria-hidden`, so textareas and buttons are removed from sequential focus and assistive interaction without triggering `aria-hidden-focus`.
+
+**Tech Stack:** Next.js App Router, React 19, TypeScript strict mode, Vitest with JSDOM, Playwright with axe-core.
+
+---
+
+## File Structure
+
+- Modify `src/app/truck-harvester-app.tsx`: mark the root app content section as inert while `onboardingState.isTourOpen` is true and add a stable test selector.
+- Modify `src/app/__tests__/truck-harvester-app.test.tsx`: prove the background section becomes inert while the tour dialog is open and does not receive `aria-hidden`.
+- Modify `e2e/a11y.spec.ts`: assert the live browser page has no `aria-hidden-focus` axe violation and that background isolation uses `inert`.
+
+### Task 1: Isolate Background Content With Inert
+
+**Files:**
+
+- Modify: `src/app/truck-harvester-app.tsx`
+
+- [ ] **Step 1: Add inert to the root app content section**
+
+Replace the root content section opening tag with:
+
+```tsx
+<section
+  className="mx-auto grid min-h-dvh w-full max-w-6xl gap-6 px-6 py-8 md:px-10"
+  data-tour-background="true"
+  inert={onboardingState.isTourOpen ? true : undefined}
+>
+```
+
+- [ ] **Step 2: Run focused typecheck**
+
+Run: `bun run typecheck`
+
+Expected: PASS with no TypeScript errors.
+
+### Task 2: Add Unit Coverage For Modal Background Isolation
+
+**Files:**
+
+- Modify: `src/app/__tests__/truck-harvester-app.test.tsx`
+
+- [ ] **Step 1: Add a focused JSDOM test**
+
+Add this test inside `describe('TruckHarvesterApp persistence', () => { ... })`:
+
+```tsx
+it('isolates the background surface with inert while onboarding is open', async () => {
+  const restoredDirectory = createTestDirectoryHandle()
+
+  installDom(restoredDirectory)
+  const { TruckHarvesterApp } = await import('../truck-harvester-app')
+
+  container = document.createElement('div')
+  document.body.append(container)
+  root = createRoot(container)
+
+  await act(async () => {
+    root?.render(<TruckHarvesterApp />)
+  })
+
+  const helpButton = Array.from(container.querySelectorAll('button')).find((button) =>
+    button.textContent?.includes('도움말')
+  )
+
+  expect(helpButton).toBeInstanceOf(HTMLButtonElement)
+
+  await act(async () => {
+    helpButton?.dispatchEvent(new dom!.window.MouseEvent('click', { bubbles: true }))
+  })
+
+  const background = container.querySelector<HTMLElement>('[data-tour-background="true"]')
+  const dialog = container.querySelector<HTMLElement>('[data-tour-modal-root="true"]')
+
+  expect(dialog).toBeInstanceOf(HTMLElement)
+  expect(background?.hasAttribute('inert')).toBe(true)
+  expect(background?.getAttribute('aria-hidden')).toBeNull()
+})
+```
+
+The `createTestDirectoryHandle()` helper should return the same minimal handle shape already used in the file:
+
+```tsx
+const createTestDirectoryHandle = (): WritableDirectoryHandle => ({
+  getDirectoryHandle: async () => {
+    throw new Error('테스트에서는 폴더에 쓰지 않습니다.')
+  },
+  getFileHandle: async () => {
+    throw new Error('테스트에서는 파일에 쓰지 않습니다.')
+  },
+  name: 'truck-test',
+  queryPermission: vi.fn().mockResolvedValue('granted'),
+  requestPermission: vi.fn().mockResolvedValue('granted'),
+})
+```
+
+- [ ] **Step 2: Run the focused app test**
+
+Run: `bun run test -- --run src/app/__tests__/truck-harvester-app.test.tsx`
+
+Expected: PASS.
+
+### Task 3: Add Browser-Level A11y Guard
+
+**Files:**
+
+- Modify: `e2e/a11y.spec.ts`
+
+- [ ] **Step 1: Assert inert is used and aria-hidden-focus is absent**
+
+After the dialog visibility assertion, add:
+
+```ts
+const backgroundState = await page.locator('[data-tour-background="true"]').evaluate((element) => ({
+  ariaHidden: element.getAttribute('aria-hidden'),
+  inert: (element as HTMLElement).inert,
+}))
+
+expect(backgroundState).toEqual({
+  ariaHidden: null,
+  inert: true,
+})
+```
+
+After collecting axe results, add:
+
+```ts
+const ariaHiddenFocusViolations = results.violations.filter(
+  (violation) => violation.id === 'aria-hidden-focus'
+)
+
+expect(ariaHiddenFocusViolations).toEqual([])
+```
+
+- [ ] **Step 2: Run the accessibility smoke test**
+
+Run: `bun run test:a11y`
+
+Expected: PASS.
+
+## Self-Review
+
+- Spec coverage: The screenshot's `aria-hidden-focus` warning is addressed without adding `aria-hidden` to focusable page regions.
+- Placeholder scan: No placeholders or deferred tasks remain.
+- Type consistency: The plan uses existing component names, selectors, and test command names from this repository.

--- a/docs/superpowers/plans/2026-04-28-aria-hidden-focus-isolation.md
+++ b/docs/superpowers/plans/2026-04-28-aria-hidden-focus-isolation.md
@@ -4,7 +4,7 @@
 
 **Goal:** Prevent onboarding from leaving focusable page controls exposed behind the modal tour without using `aria-hidden` on those controls.
 
-**Architecture:** Keep the existing custom tour overlay and isolate only the background app surface while the tour dialog is open. Use the native `inert` attribute on the background section, not `aria-hidden`, so textareas and buttons are removed from sequential focus and assistive interaction without triggering `aria-hidden-focus`.
+**Architecture:** Keep the existing custom tour overlay and isolate only the background app surface while the tour dialog is open. Use the native `inert` attribute on the background section, not `aria-hidden`, and explicitly disable background buttons and the address textarea so accessibility scanners do not see focusable descendants inside the hidden app surface.
 
 **Tech Stack:** Next.js App Router, React 19, TypeScript strict mode, Vitest with JSDOM, Playwright with axe-core.
 
@@ -12,9 +12,12 @@
 
 ## File Structure
 
-- Modify `src/app/truck-harvester-app.tsx`: mark the root app content section as inert while `onboardingState.isTourOpen` is true and add a stable test selector.
-- Modify `src/app/__tests__/truck-harvester-app.test.tsx`: prove the background section becomes inert while the tour dialog is open and does not receive `aria-hidden`.
-- Modify `e2e/a11y.spec.ts`: assert the live browser page has no `aria-hidden-focus` axe violation and that background isolation uses `inert`.
+- Modify `src/app/truck-harvester-app.tsx`: mark the root app content section as inert while `onboardingState.isTourOpen` is true, add a stable test selector, and pass disabled state to background controls.
+- Modify `src/v2/features/onboarding/ui/help-menu-button.tsx`: accept a disabled prop for the header help control.
+- Modify `src/v2/widgets/directory-selector/ui/directory-selector.tsx`: accept a disabled prop for the save-folder control.
+- Modify `src/v2/features/completion-notification/ui/completion-notification-toggle.tsx`: accept a disabled prop for the optional notification control.
+- Modify `src/app/__tests__/truck-harvester-app.test.tsx`: prove the background section becomes inert, avoids `aria-hidden`, and disables the four focusable background controls while the tour dialog is open.
+- Modify `e2e/a11y.spec.ts`: assert the live browser page has no `aria-hidden-focus` axe violation and that background isolation uses `inert` plus disabled controls.
 
 ### Task 1: Isolate Background Content With Inert
 
@@ -30,7 +33,7 @@ Replace the root content section opening tag with:
 <section
   className="mx-auto grid min-h-dvh w-full max-w-6xl gap-6 px-6 py-8 md:px-10"
   data-tour-background="true"
-  inert={onboardingState.isTourOpen ? true : undefined}
+  inert={isTourOpen ? true : undefined}
 >
 ```
 
@@ -51,10 +54,17 @@ Expected: PASS with no TypeScript errors.
 Add this test inside `describe('TruckHarvesterApp persistence', () => { ... })`:
 
 ```tsx
-it('isolates the background surface with inert while onboarding is open', async () => {
+it('disables the four background controls while onboarding is open', async () => {
   const restoredDirectory = createTestDirectoryHandle()
 
   installDom(restoredDirectory)
+  Object.defineProperty(window, 'Notification', {
+    configurable: true,
+    value: {
+      permission: 'default',
+      requestPermission: vi.fn().mockResolvedValue('default'),
+    },
+  })
   const { TruckHarvesterApp } = await import('../truck-harvester-app')
 
   container = document.createElement('div')
@@ -81,6 +91,19 @@ it('isolates the background surface with inert while onboarding is open', async 
   expect(dialog).toBeInstanceOf(HTMLElement)
   expect(background?.hasAttribute('inert')).toBe(true)
   expect(background?.getAttribute('aria-hidden')).toBeNull()
+
+  const textarea = container.querySelector<HTMLTextAreaElement>('#listing-chip-input-textarea')
+  const directoryButton = Array.from(container.querySelectorAll('button')).find(
+    (button) => button.textContent === '저장 폴더 고르기'
+  )
+  const notificationButton = Array.from(container.querySelectorAll('button')).find(
+    (button) => button.textContent === '완료 알림 켜기'
+  )
+
+  expect(helpButton?.disabled).toBe(true)
+  expect(textarea?.disabled).toBe(true)
+  expect(directoryButton?.disabled).toBe(true)
+  expect(notificationButton?.disabled).toBe(true)
 })
 ```
 
@@ -126,6 +149,11 @@ expect(backgroundState).toEqual({
   ariaHidden: null,
   inert: true,
 })
+
+await expect(page.getByRole('button', { name: /도움말/ })).toBeDisabled()
+await expect(page.locator('#listing-chip-input-textarea')).toBeDisabled()
+await expect(page.getByRole('button', { name: '저장 폴더 고르기' })).toBeDisabled()
+await expect(page.getByRole('button', { name: '완료 알림 켜기' })).toBeDisabled()
 ```
 
 After collecting axe results, add:

--- a/e2e/a11y.spec.ts
+++ b/e2e/a11y.spec.ts
@@ -7,13 +7,29 @@ test('v2 landing flow has no critical accessibility violations', async ({
   await page.goto('/')
   await expect(page.getByRole('dialog')).toBeVisible()
 
+  const backgroundState = await page
+    .locator('[data-tour-background="true"]')
+    .evaluate((element) => ({
+      ariaHidden: element.getAttribute('aria-hidden'),
+      inert: (element as HTMLElement).inert,
+    }))
+
+  expect(backgroundState).toEqual({
+    ariaHidden: null,
+    inert: true,
+  })
+
   const results = await new AxeBuilder({ page })
     .include('[data-tour="v2-page"]')
     .include('[data-tour-modal-root="true"]')
     .analyze()
+  const ariaHiddenFocusViolations = results.violations.filter(
+    (violation) => violation.id === 'aria-hidden-focus'
+  )
   const criticalViolations = results.violations.filter(
     (violation) => violation.impact === 'critical'
   )
 
+  expect(ariaHiddenFocusViolations).toEqual([])
   expect(criticalViolations).toEqual([])
 })

--- a/e2e/a11y.spec.ts
+++ b/e2e/a11y.spec.ts
@@ -4,6 +4,19 @@ import { expect, test } from '@playwright/test'
 test('v2 landing flow has no critical accessibility violations', async ({
   page,
 }) => {
+  await page.addInitScript(() => {
+    class FakeNotification {
+      static permission: NotificationPermission = 'default'
+      static requestPermission = async () => 'default' as NotificationPermission
+
+      constructor(_title: string) {}
+    }
+
+    Object.defineProperty(window, 'Notification', {
+      configurable: true,
+      value: FakeNotification,
+    })
+  })
   await page.goto('/')
   await expect(page.getByRole('dialog')).toBeVisible()
 
@@ -18,6 +31,14 @@ test('v2 landing flow has no critical accessibility violations', async ({
     ariaHidden: null,
     inert: true,
   })
+  await expect(page.getByRole('button', { name: /도움말/ })).toBeDisabled()
+  await expect(page.locator('#listing-chip-input-textarea')).toBeDisabled()
+  await expect(
+    page.getByRole('button', { name: '저장 폴더 고르기' })
+  ).toBeDisabled()
+  await expect(
+    page.getByRole('button', { name: '완료 알림 켜기' })
+  ).toBeDisabled()
 
   const results = await new AxeBuilder({ page })
     .include('[data-tour="v2-page"]')

--- a/src/app/__tests__/truck-harvester-app.test.tsx
+++ b/src/app/__tests__/truck-harvester-app.test.tsx
@@ -6,6 +6,7 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { type WritableDirectoryHandle } from '@/v2/features/file-management'
+import { onboardingStorageKey } from '@/v2/shared/model'
 
 vi.mock('@/v2/features/listing-preparation', async () => {
   const prepare = await vi.importActual<
@@ -78,6 +79,10 @@ const createRequest = <T,>(result: T): FakeIdbRequest<T> => ({
   onsuccess: null,
   result,
 })
+
+const markOnboardingComplete = () => {
+  window.localStorage.setItem(onboardingStorageKey, 'completed')
+}
 
 const installDom = (storedDirectory: WritableDirectoryHandle) => {
   const currentDom = new JSDOM('<!doctype html><html><body></body></html>', {
@@ -200,10 +205,17 @@ afterEach(() => {
 })
 
 describe('TruckHarvesterApp persistence', () => {
-  it('isolates the background surface with inert while onboarding is open', async () => {
+  it('disables the four background controls while onboarding is open', async () => {
     const restoredDirectory = createTestDirectoryHandle()
 
     installDom(restoredDirectory)
+    Object.defineProperty(window, 'Notification', {
+      configurable: true,
+      value: {
+        permission: 'default',
+        requestPermission: vi.fn().mockResolvedValue('default'),
+      },
+    })
     const { TruckHarvesterApp } = await import('../truck-harvester-app')
 
     container = document.createElement('div')
@@ -236,6 +248,21 @@ describe('TruckHarvesterApp persistence', () => {
     expect(dialog).toBeInstanceOf(HTMLElement)
     expect(background?.hasAttribute('inert')).toBe(true)
     expect(background?.getAttribute('aria-hidden')).toBeNull()
+
+    const textarea = container.querySelector<HTMLTextAreaElement>(
+      '#listing-chip-input-textarea'
+    )
+    const directoryButton = Array.from(
+      container.querySelectorAll('button')
+    ).find((button) => button.textContent === '저장 폴더 고르기')
+    const notificationButton = Array.from(
+      container.querySelectorAll('button')
+    ).find((button) => button.textContent === '완료 알림 켜기')
+
+    expect(helpButton?.disabled).toBe(true)
+    expect(textarea?.disabled).toBe(true)
+    expect(directoryButton?.disabled).toBe(true)
+    expect(notificationButton?.disabled).toBe(true)
   })
 
   it('does not restore a persisted writable folder after client mount', async () => {
@@ -254,6 +281,7 @@ describe('TruckHarvesterApp persistence', () => {
     }
 
     installDom(restoredDirectory)
+    markOnboardingComplete()
     const { TruckHarvesterApp } = await import('../truck-harvester-app')
 
     container = document.createElement('div')
@@ -302,6 +330,7 @@ describe('TruckHarvesterApp persistence', () => {
     }
 
     installDom(restoredDirectory)
+    markOnboardingComplete()
     Object.defineProperty(globalThis, 'fetch', {
       configurable: true,
       value: vi.fn().mockResolvedValue(

--- a/src/app/__tests__/truck-harvester-app.test.tsx
+++ b/src/app/__tests__/truck-harvester-app.test.tsx
@@ -60,6 +60,18 @@ let container: HTMLDivElement | null = null
 let dom: JsdomInstance | null = null
 const originalFetch = globalThis.fetch
 
+const createTestDirectoryHandle = (): WritableDirectoryHandle => ({
+  getDirectoryHandle: async () => {
+    throw new Error('테스트에서는 폴더에 쓰지 않습니다.')
+  },
+  getFileHandle: async () => {
+    throw new Error('테스트에서는 파일에 쓰지 않습니다.')
+  },
+  name: 'truck-test',
+  queryPermission: vi.fn().mockResolvedValue('granted'),
+  requestPermission: vi.fn().mockResolvedValue('granted'),
+})
+
 const createRequest = <T,>(result: T): FakeIdbRequest<T> => ({
   error: null,
   onerror: null,
@@ -188,6 +200,44 @@ afterEach(() => {
 })
 
 describe('TruckHarvesterApp persistence', () => {
+  it('isolates the background surface with inert while onboarding is open', async () => {
+    const restoredDirectory = createTestDirectoryHandle()
+
+    installDom(restoredDirectory)
+    const { TruckHarvesterApp } = await import('../truck-harvester-app')
+
+    container = document.createElement('div')
+    document.body.append(container)
+    root = createRoot(container)
+
+    await act(async () => {
+      root?.render(<TruckHarvesterApp />)
+    })
+
+    const helpButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent?.includes('도움말')
+    )
+
+    expect(helpButton).toBeInstanceOf(HTMLButtonElement)
+
+    await act(async () => {
+      helpButton?.dispatchEvent(
+        new dom!.window.MouseEvent('click', { bubbles: true })
+      )
+    })
+
+    const background = container.querySelector<HTMLElement>(
+      '[data-tour-background="true"]'
+    )
+    const dialog = container.querySelector<HTMLElement>(
+      '[data-tour-modal-root="true"]'
+    )
+
+    expect(dialog).toBeInstanceOf(HTMLElement)
+    expect(background?.hasAttribute('inert')).toBe(true)
+    expect(background?.getAttribute('aria-hidden')).toBeNull()
+  })
+
   it('does not restore a persisted writable folder after client mount', async () => {
     const queryPermission = vi.fn().mockResolvedValue('granted')
     const requestPermission = vi.fn().mockResolvedValue('granted')

--- a/src/app/truck-harvester-app.tsx
+++ b/src/app/truck-harvester-app.tsx
@@ -385,7 +385,11 @@ export function TruckHarvesterApp() {
       className="bg-background text-foreground min-h-dvh"
       data-tour="v2-page"
     >
-      <section className="mx-auto grid min-h-dvh w-full max-w-6xl gap-6 px-6 py-8 md:px-10">
+      <section
+        className="mx-auto grid min-h-dvh w-full max-w-6xl gap-6 px-6 py-8 md:px-10"
+        data-tour-background="true"
+        inert={onboardingState.isTourOpen ? true : undefined}
+      >
         <header className="flex items-center justify-between gap-4">
           <div>
             <p className="text-muted-foreground text-sm font-medium">

--- a/src/app/truck-harvester-app.tsx
+++ b/src/app/truck-harvester-app.tsx
@@ -95,6 +95,7 @@ export function TruckHarvesterApp() {
   const inputListings = preparedState.items.filter(
     (item) => item.status !== 'saved'
   )
+  const isTourOpen = onboardingState.isTourOpen
 
   useBrowserLayoutEffect(() => {
     const supported = isFileSystemAccessAvailable()
@@ -388,7 +389,7 @@ export function TruckHarvesterApp() {
       <section
         className="mx-auto grid min-h-dvh w-full max-w-6xl gap-6 px-6 py-8 md:px-10"
         data-tour-background="true"
-        inert={onboardingState.isTourOpen ? true : undefined}
+        inert={isTourOpen ? true : undefined}
       >
         <header className="flex items-center justify-between gap-4">
           <div>
@@ -399,7 +400,10 @@ export function TruckHarvesterApp() {
               트럭 매물 수집기
             </h1>
           </div>
-          <HelpMenuButton onRestartTour={onboardingState.restartTour} />
+          <HelpMenuButton
+            disabled={isTourOpen}
+            onRestartTour={onboardingState.restartTour}
+          />
         </header>
 
         <div className="grid gap-5 lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]">
@@ -407,7 +411,7 @@ export function TruckHarvesterApp() {
             <div data-tour="url-input">
               <ListingChipInput
                 canRemoveItem={canRemovePreparedItem}
-                disabled={isSaving}
+                disabled={isSaving || isTourOpen}
                 duplicateMessage={duplicateMessage}
                 items={inputListings}
                 onPasteText={handlePasteText}
@@ -419,6 +423,7 @@ export function TruckHarvesterApp() {
 
           <div className="grid content-start gap-5">
             <DirectorySelector
+              disabled={isTourOpen}
               isSupported={fileSystemSupported}
               onSelectDirectory={selectDirectory}
               permissionState={directoryPermissionState}
@@ -430,6 +435,7 @@ export function TruckHarvesterApp() {
               selectedDirectoryName={directory?.name}
             />
             <CompletionNotificationToggle
+              disabled={isTourOpen}
               isAvailable={notificationAvailable}
               onEnable={requestNotificationPermission}
               permission={notificationPermission}

--- a/src/v2/features/completion-notification/ui/completion-notification-toggle.tsx
+++ b/src/v2/features/completion-notification/ui/completion-notification-toggle.tsx
@@ -5,12 +5,14 @@ import { BellOff, CheckCircle2 } from 'lucide-react'
 import { Button } from '@/v2/shared/ui/button'
 
 interface CompletionNotificationToggleProps {
+  disabled?: boolean
   isAvailable: boolean
   permission: NotificationPermission | 'unsupported'
   onEnable: () => void
 }
 
 export function CompletionNotificationToggle({
+  disabled = false,
   isAvailable,
   permission,
   onEnable,
@@ -39,7 +41,13 @@ export function CompletionNotificationToggle({
 
   return (
     <div className="inline-flex items-center gap-2">
-      <Button onClick={onEnable} size="sm" type="button" variant="outline">
+      <Button
+        disabled={disabled}
+        onClick={onEnable}
+        size="sm"
+        type="button"
+        variant="outline"
+      >
         완료 알림 켜기
       </Button>
       <span className="text-muted-foreground text-xs">선택 사항</span>

--- a/src/v2/features/onboarding/ui/help-menu-button.tsx
+++ b/src/v2/features/onboarding/ui/help-menu-button.tsx
@@ -5,12 +5,21 @@ import { CircleHelp } from 'lucide-react'
 import { Button } from '@/v2/shared/ui/button'
 
 interface HelpMenuButtonProps {
+  disabled?: boolean
   onRestartTour: () => void
 }
 
-export function HelpMenuButton({ onRestartTour }: HelpMenuButtonProps) {
+export function HelpMenuButton({
+  disabled = false,
+  onRestartTour,
+}: HelpMenuButtonProps) {
   return (
-    <Button onClick={onRestartTour} type="button" variant="outline">
+    <Button
+      disabled={disabled}
+      onClick={onRestartTour}
+      type="button"
+      variant="outline"
+    >
       <CircleHelp aria-hidden="true" data-icon="inline-start" />
       도움말
       <span className="sr-only">처음 안내 다시 보기</span>

--- a/src/v2/widgets/directory-selector/ui/directory-selector.tsx
+++ b/src/v2/widgets/directory-selector/ui/directory-selector.tsx
@@ -18,6 +18,7 @@ type DirectoryPermissionState =
 type DirectoryPickerStartIn = WritableDirectoryHandle | 'downloads'
 
 interface DirectorySelectorProps {
+  disabled?: boolean
   isSupported?: boolean
   onSelectDirectory: (
     directory: WritableDirectoryHandle
@@ -33,6 +34,7 @@ const pickSaveDirectory = pickWritableDirectory as (options: {
 }) => Promise<WritableDirectoryHandle | undefined>
 
 export function DirectorySelector({
+  disabled = false,
   isSupported = isFileSystemAccessAvailable(),
   onSelectDirectory,
   permissionState = 'ready',
@@ -67,6 +69,7 @@ export function DirectorySelector({
       </div>
       <div>
         <Button
+          disabled={disabled}
           onClick={async () => {
             const directory = await pickSaveDirectory({
               id: 'truck-harvester-v2-save-folder',


### PR DESCRIPTION
## Summary
- 온보딩 투어가 열렸을 때 배경 앱 섹션을 `inert`로 격리합니다.
- 도움말, 주소 입력란, 저장 폴더 선택, 완료 알림 버튼을 투어 중 비활성화해 `aria-hidden-focus` 경고 대상이 되지 않도록 보강했습니다.
- JSDOM과 Playwright/axe 회귀 테스트로 네 배경 포커스 대상을 직접 검증합니다.
- superpowers 계획 문서에 접근성 개선 계획을 최신화했습니다.

## Verification
- `bun run typecheck`
- `bun run lint`
- `bun run test -- --run`
- `bun run test:coverage -- --run` (statements 86.56%, branches 75.49%, functions 88.11%, lines 86.32%)
- `bun run build`
- `bun run test:a11y`

## Notes
- `bun run format:check` still fails on pre-existing formatting issues in `src/app/apple-icon.tsx`, `src/app/icon.tsx`, and `src/app/opengraph-image.tsx`; changed files pass Prettier check.