### PR TITLE
refactor: separate truck harvester workflow tracking

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,6 +37,12 @@ bounded input sample, vehicle number, and vehicle name; successful listings are
 represented by counts only. Unsupported input samples are whitespace-normalized,
 capped at 160 characters, and sent at most once per failed paste.
 
+The application workflow layer emits business facts to a workflow analytics
+adapter. The route component and widgets do not assemble Umami payloads, and
+preview/save use cases do not call `window.umami` directly. The shared
+analytics transport remains the only layer that knows the concrete Umami event
+names and payload keys.
+
 The client owns preview scheduling with concurrency 5. The server endpoint
 accepts one address at a time so each request can stay inside the short
 Vercel Hobby execution budget. The visible user state is the prepared
@@ -87,13 +93,16 @@ users choose the save folder again.
 
 ## Layer Responsibilities
 
-- `src/app`: root route composition, page layout, and wiring.
+- `src/app`: root route composition, page layout, and widget wiring.
+- `src/v2/application`: root app workflow orchestration, React hook adapters,
+  and workflow analytics boundaries.
 - `src/v2/widgets`: user-facing blocks that compose features and shared
   selectors.
-- `src/v2/features`: workflows such as listing preparation, parsing,
+- `src/v2/features`: capabilities such as listing preparation, parsing,
   saving, completion notifications, and onboarding.
 - `src/v2/entities`: pure schemas and state contracts.
-- `src/v2/shared`: utilities, stores, selectors, and low-level UI.
+- `src/v2/shared`: utilities, stores, selectors, analytics transport, and
+  low-level UI.
 - `src/v2/design-system`: tokens and motion presets for the root app.
 
 ## Guardrails

--- a/docs/superpowers/plans/2026-04-30-business-tracking-separation.md
+++ b/docs/superpowers/plans/2026-04-30-business-tracking-separation.md
@@ -346,8 +346,10 @@ export * from './truck-harvester-workflow'
 Create `src/v2/application/truck-harvester-workflow/index.ts`:
 
 ```ts
-export * from './use-truck-harvester-workflow'
+export {}
 ```
+
+This is a temporary empty module until Task 6 creates the workflow hook.
 
 - [ ] **Step 5: Run the knowledge-base test to verify it passes**
 
@@ -1567,7 +1569,7 @@ git commit -m "refactor: 저장 workflow use case 분리"
 - Create: `src/v2/application/truck-harvester-workflow/use-truck-harvester-workflow.ts`
 - Modify: `src/v2/application/truck-harvester-workflow/index.ts`
 
-- [ ] **Step 1: Write the hook export before implementation**
+- [ ] **Step 1: Replace the temporary barrel with the hook export**
 
 Replace `src/v2/application/truck-harvester-workflow/index.ts`:
 
@@ -1966,7 +1968,7 @@ export function TruckHarvesterApp() {
   const workflow = useTruckHarvesterWorkflow()
 
   return (
-    <main className="bg-background text-foreground min-h-dvh" data-tour="v2-page">
+    <main className="min-h-dvh bg-background text-foreground" data-tour="v2-page">
       <section
         className="mx-auto grid min-h-dvh w-full max-w-6xl gap-6 px-6 py-8 md:px-10"
         data-tour-background="true"
@@ -1974,8 +1976,8 @@ export function TruckHarvesterApp() {
       >
         <header className="flex items-center justify-between gap-4">
           <div>
-            <p className="text-muted-foreground text-sm font-medium">새 작업 화면</p>
-            <h1 className="text-foreground text-2xl font-semibold tracking-normal">
+            <p className="text-sm font-medium text-muted-foreground">새 작업 화면</p>
+            <h1 className="text-2xl font-semibold tracking-normal text-foreground">
               트럭 매물 수집기
             </h1>
           </div>

--- a/docs/superpowers/plans/2026-04-30-business-tracking-separation.md
+++ b/docs/superpowers/plans/2026-04-30-business-tracking-separation.md
@@ -1,0 +1,2212 @@
+# Business Tracking Separation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Separate Truck Harvester business workflow orchestration from Umami tracking details by introducing a focused `src/v2/application` layer.
+
+**Architecture:** Add an application workflow slice between the root route and existing `features/*` capabilities. Keep preview/save use cases mostly React-free, keep browser lifecycle in `useTruckHarvesterWorkflow`, and isolate business fact to Umami payload conversion in `workflow-analytics.ts`.
+
+**Tech Stack:** Next.js App Router, React 19, TypeScript strict mode, Zustand vanilla stores, Vitest, Umami Cloud tracker.
+
+---
+
+## Scope Check
+
+This plan covers one subsystem: the root Truck Harvester paste-preview-save workflow and its tracking boundary. It does not redesign UI, change Umami event names, add analytics providers, change save-folder persistence, or alter default concurrency.
+
+## File Structure
+
+- Create `src/v2/application/AGENTS.md`: Documents the application layer import rules and workflow ownership.
+- Create `src/v2/application/index.ts`: Public application layer barrel.
+- Create `src/v2/application/truck-harvester-workflow/index.ts`: Workflow slice public API.
+- Create `src/v2/application/truck-harvester-workflow/workflow-analytics.ts`: Converts workflow facts into existing analytics wrapper calls and owns batch/listing mapping.
+- Create `src/v2/application/truck-harvester-workflow/workflow-analytics.test.ts`: Unit coverage for analytics adapter state and payload conversion.
+- Create `src/v2/application/truck-harvester-workflow/preview-workflow.ts`: Handles pasted text parsing, preview scheduling, duplicate helper state, and preview tracking facts.
+- Create `src/v2/application/truck-harvester-workflow/preview-workflow.test.ts`: Unit coverage for supported input, unsupported input, duplicate input, preview failures, and abort cleanup.
+- Create `src/v2/application/truck-harvester-workflow/save-workflow.ts`: Handles ready-listing save orchestration and save tracking facts.
+- Create `src/v2/application/truck-harvester-workflow/save-workflow.test.ts`: Unit coverage for directory and ZIP save outcomes.
+- Create `src/v2/application/truck-harvester-workflow/use-truck-harvester-workflow.ts`: React adapter for stores, abort controllers, directory state, notification state, and workflow commands.
+- Create `src/v2/features/listing-preparation/model/url-input-parser.ts`: Moves supported address extraction out of widget ownership.
+- Create `src/v2/features/listing-preparation/model/__tests__/url-input-parser.test.ts`: Feature-level parser tests.
+- Modify `src/v2/widgets/url-input/model/url-input-schema.ts`: Re-export parser helpers from the feature layer for existing widget imports.
+- Modify `src/v2/features/listing-preparation/index.ts`: Export parser helpers and prepared-listing workflow types used by application use cases.
+- Modify `src/app/truck-harvester-app.tsx`: Replace embedded orchestration and analytics helpers with `useTruckHarvesterWorkflow`.
+- Modify `src/app/__tests__/truck-harvester-app.test.tsx`: Keep UI integration assertions while moving analytics payload specifics to application tests.
+- Modify `src/v2/AGENTS.md`: Add the application layer to the layer map.
+- Modify `src/v2/testing/__tests__/knowledge-base.test.ts`: Require the new application AGENTS guide.
+- Modify `docs/architecture.md`: Document the application layer and tracking adapter boundary.
+
+## Task 1: Move Paste URL Parsing Into The Feature Layer
+
+**Files:**
+
+- Create: `src/v2/features/listing-preparation/model/url-input-parser.ts`
+- Create: `src/v2/features/listing-preparation/model/__tests__/url-input-parser.test.ts`
+- Modify: `src/v2/widgets/url-input/model/url-input-schema.ts`
+- Modify: `src/v2/features/listing-preparation/index.ts`
+
+- [ ] **Step 1: Write the feature-level parser test**
+
+Create `src/v2/features/listing-preparation/model/__tests__/url-input-parser.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest'
+
+import { extractTruckUrlsFromText, parseUrlInputText } from '../url-input-parser'
+
+const validUrl = 'https://www.truck-no1.co.kr/model/DetailView.asp?ShopNo=1&MemberNo=2&OnCarNo=3'
+
+describe('listing preparation url input parser', () => {
+  it('extracts supported truck listing addresses from pasted prose', () => {
+    expect(extractTruckUrlsFromText(`확인 부탁드립니다\n${validUrl})\n감사합니다`)).toEqual([
+      validUrl,
+    ])
+  })
+
+  it('deduplicates normalized listing addresses', () => {
+    expect(extractTruckUrlsFromText(`${validUrl}\n${validUrl}.`)).toEqual([validUrl])
+  })
+
+  it('returns Korean empty-input guidance for whitespace', () => {
+    expect(parseUrlInputText(' \n\t ')).toEqual({
+      success: false,
+      message: '매물 주소를 찾지 못했어요. 복사한 내용을 다시 확인해 주세요.',
+    })
+  })
+
+  it('returns Korean invalid-input guidance when no supported address exists', () => {
+    expect(parseUrlInputText('DetailView.asp?ShopNo=1')).toEqual({
+      success: false,
+      message: '매물 주소를 찾지 못했어요. 복사한 내용을 다시 확인해 주세요.',
+    })
+  })
+
+  it('returns supported listing addresses for valid pasted input', () => {
+    expect(parseUrlInputText(`메모\n${validUrl}`)).toEqual({
+      success: true,
+      urls: [validUrl],
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run the parser test to verify it fails**
+
+Run:
+
+```bash
+bun run test -- --run src/v2/features/listing-preparation/model/__tests__/url-input-parser.test.ts
+```
+
+Expected: FAIL because `../url-input-parser` does not exist.
+
+- [ ] **Step 3: Create the feature-owned parser**
+
+Create `src/v2/features/listing-preparation/model/url-input-parser.ts`:
+
+```ts
+import { normalizeTruckUrl } from '@/v2/entities/url'
+import { v2Copy } from '@/v2/shared/lib/copy'
+
+export interface UrlInputSuccess {
+  success: true
+  urls: string[]
+}
+
+export interface UrlInputFailure {
+  success: false
+  message: string
+}
+
+export type UrlInputResult = UrlInputSuccess | UrlInputFailure
+
+const supportedTruckUrlPattern =
+  /https?:\/\/www\.truck-no1\.co\.kr\/model\/DetailView\.asp\?[A-Za-z0-9\-._~:/?#[\]@!$&'()*+,;=%]+/gi
+const trailingChatPunctuationPattern = /[.,)\]}]+$/g
+
+const stripTrailingChatPunctuation = (value: string) =>
+  value.replace(trailingChatPunctuationPattern, '')
+
+export function extractTruckUrlsFromText(value: string): string[] {
+  const normalizedUrls = new Set<string>()
+  const matches = value.match(supportedTruckUrlPattern) ?? []
+
+  for (const match of matches) {
+    try {
+      normalizedUrls.add(normalizeTruckUrl(stripTrailingChatPunctuation(match)))
+    } catch {
+      continue
+    }
+  }
+
+  return Array.from(normalizedUrls)
+}
+
+export function parseUrlInputText(value: string): UrlInputResult {
+  if (value.trim().length === 0) {
+    return {
+      success: false,
+      message: v2Copy.urlInput.errors.empty,
+    }
+  }
+
+  const urls = extractTruckUrlsFromText(value)
+
+  if (urls.length === 0) {
+    return {
+      success: false,
+      message: v2Copy.urlInput.errors.invalid,
+    }
+  }
+
+  return {
+    success: true,
+    urls,
+  }
+}
+```
+
+- [ ] **Step 4: Run the parser test to verify it passes**
+
+Run:
+
+```bash
+bun run test -- --run src/v2/features/listing-preparation/model/__tests__/url-input-parser.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the feature parser**
+
+```bash
+git add src/v2/features/listing-preparation/model/url-input-parser.ts src/v2/features/listing-preparation/model/__tests__/url-input-parser.test.ts
+git commit -m "refactor: 입력 주소 파서 feature 계층 이동"
+```
+
+- [ ] **Step 6: Re-export parser helpers without changing widget imports**
+
+Replace `src/v2/widgets/url-input/model/url-input-schema.ts` with:
+
+```ts
+export {
+  extractTruckUrlsFromText,
+  parseUrlInputText,
+} from '@/v2/features/listing-preparation/model/url-input-parser'
+export type {
+  UrlInputFailure,
+  UrlInputResult,
+  UrlInputSuccess,
+} from '@/v2/features/listing-preparation/model/url-input-parser'
+```
+
+Modify `src/v2/features/listing-preparation/index.ts`:
+
+```ts
+export {
+  prepareListingUrls,
+  type PreparedListingRunItem,
+  type PreparedListingSettledItem,
+  type PrepareListingUrlsInput,
+} from './model/prepare-listings'
+export * from './model/prepared-listing-store'
+export {
+  extractTruckUrlsFromText,
+  parseUrlInputText,
+  type UrlInputFailure,
+  type UrlInputResult,
+  type UrlInputSuccess,
+} from './model/url-input-parser'
+```
+
+- [ ] **Step 7: Run existing URL input tests**
+
+Run:
+
+```bash
+bun run test -- --run src/v2/widgets/url-input/model/__tests__/url-input-schema.test.ts src/v2/widgets/url-input/ui/__tests__/listing-chip-input.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit parser re-exports**
+
+```bash
+git add src/v2/widgets/url-input/model/url-input-schema.ts src/v2/features/listing-preparation/index.ts
+git commit -m "refactor: 입력 주소 파서 공개 경로 정리"
+```
+
+## Task 2: Add The Application Layer Guide And Barrels
+
+**Files:**
+
+- Create: `src/v2/application/AGENTS.md`
+- Create: `src/v2/application/index.ts`
+- Create: `src/v2/application/truck-harvester-workflow/index.ts`
+- Modify: `src/v2/AGENTS.md`
+- Modify: `src/v2/testing/__tests__/knowledge-base.test.ts`
+
+- [ ] **Step 1: Write the failing knowledge-base assertion**
+
+Modify `src/v2/testing/__tests__/knowledge-base.test.ts` so `layerAgentFiles` includes the application guide:
+
+```ts
+const layerAgentFiles = [
+  'AGENTS.md',
+  'src/v2/AGENTS.md',
+  'src/v2/application/AGENTS.md',
+  'src/v2/entities/AGENTS.md',
+  'src/v2/features/AGENTS.md',
+  'src/v2/shared/AGENTS.md',
+  'src/v2/widgets/AGENTS.md',
+]
+```
+
+Add this test inside `describe('v2 AI knowledge base', () => { ... })`:
+
+```ts
+it('documents the application workflow layer', () => {
+  const guide = readText('src/v2/AGENTS.md')
+  const applicationGuide = readText('src/v2/application/AGENTS.md')
+
+  expect(guide).toContain('application/')
+  expect(applicationGuide).toContain('business workflow orchestration')
+  expect(applicationGuide).toContain('must not import widgets')
+  expect(applicationGuide).toContain('workflow analytics')
+})
+```
+
+- [ ] **Step 2: Run the knowledge-base test to verify it fails**
+
+Run:
+
+```bash
+bun run test -- --run src/v2/testing/__tests__/knowledge-base.test.ts
+```
+
+Expected: FAIL because `src/v2/application/AGENTS.md` does not exist.
+
+- [ ] **Step 3: Add the application AGENTS guide and layer map**
+
+Create `src/v2/application/AGENTS.md`:
+
+```md
+# src/v2/application AGENTS.md
+
+`src/v2/application` contains business workflow orchestration for the root
+Truck Harvester app. It coordinates feature capabilities, browser adapters,
+and workflow analytics without owning user-facing widgets.
+
+## Responsibilities
+
+- Own paste-preview-save use cases that span multiple feature slices.
+- Keep business workflow code testable outside React when possible.
+- Keep React lifecycle, abort controllers, and browser permission state inside
+  hook adapters.
+- Convert workflow facts to analytics through a workflow analytics adapter.
+
+## Rules
+
+- Application code may import from `src/v2/entities`, `src/v2/features`, and
+  `src/v2/shared`.
+- Application code must not import widgets.
+- Features, shared helpers, and widgets must not import application code.
+- UI components must not call analytics tracking functions directly.
+- Workflow analytics observes facts and must not mutate prepared listing state.
+
+## Knowledge Links
+
+- Workflow architecture: `docs/architecture.md`
+- Decisions: `docs/decisions/`
+- Runbooks: `docs/runbooks/`
+```
+
+Modify the Layer Map in `src/v2/AGENTS.md`:
+
+```md
+- `application/`: root app business workflow orchestration, React hook
+  adapters, and workflow analytics boundaries.
+- `design-system/`: token docs and TypeScript helpers for CSS variables.
+- `shared/`: base utilities, UI primitives, stores, and cross-feature
+  helpers that do not know about a specific widget.
+- `entities/`: pure domain schemas for truck listings, input addresses,
+  downloads, and per-item states.
+- `features/`: capabilities such as parsing, retrying, saving, and
+  onboarding.
+- `widgets/`: composed UI blocks for the root page.
+```
+
+- [ ] **Step 4: Add application public barrels**
+
+Create `src/v2/application/index.ts`:
+
+```ts
+export * from './truck-harvester-workflow'
+```
+
+Create `src/v2/application/truck-harvester-workflow/index.ts`:
+
+```ts
+export * from './use-truck-harvester-workflow'
+```
+
+- [ ] **Step 5: Run the knowledge-base test to verify it passes**
+
+Run:
+
+```bash
+bun run test -- --run src/v2/testing/__tests__/knowledge-base.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit layer documentation**
+
+```bash
+git add src/v2/application/AGENTS.md src/v2/AGENTS.md src/v2/testing/__tests__/knowledge-base.test.ts
+git commit -m "docs: application 계층 가이드 추가"
+```
+
+- [ ] **Step 7: Commit application barrels**
+
+```bash
+git add src/v2/application/index.ts src/v2/application/truck-harvester-workflow/index.ts
+git commit -m "refactor: application workflow 공개 경로 추가"
+```
+
+## Task 3: Introduce The Workflow Analytics Adapter
+
+**Files:**
+
+- Create: `src/v2/application/truck-harvester-workflow/workflow-analytics.ts`
+- Create: `src/v2/application/truck-harvester-workflow/workflow-analytics.test.ts`
+
+- [ ] **Step 1: Write the analytics adapter tests**
+
+Create `src/v2/application/truck-harvester-workflow/workflow-analytics.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from 'vitest'
+
+import { type TruckListing } from '@/v2/entities/truck'
+
+import { createWorkflowAnalytics } from './workflow-analytics'
+
+const firstUrl = 'https://www.truck-no1.co.kr/model/DetailView.asp?ShopNo=1&MemberNo=2&OnCarNo=3'
+
+const listing: TruckListing = {
+  url: firstUrl,
+  vname: '현대 메가트럭',
+  vehicleName: '현대 메가트럭',
+  vnumber: '서울12가3456',
+  price: {
+    raw: 3200,
+    rawWon: 32000000,
+    label: '3,200만원',
+    compactLabel: '3,200만원',
+  },
+  year: '2020',
+  mileage: '120,000km',
+  options: '윙바디',
+  images: ['https://img.example.com/1.jpg'],
+}
+
+const createTransport = () => ({
+  trackBatchStarted: vi.fn(),
+  trackListingFailed: vi.fn(),
+  trackPreviewCompleted: vi.fn(),
+  trackSaveCompleted: vi.fn(),
+  trackSaveFailed: vi.fn(),
+  trackSaveStarted: vi.fn(),
+  trackUnsupportedInputFailure: vi.fn(),
+})
+
+describe('workflow analytics adapter', () => {
+  it('tracks unsupported input without exposing Umami details to callers', () => {
+    const transport = createTransport()
+    const tracker = createWorkflowAnalytics({
+      createBatchId: () => 'batch-unsupported',
+      getFilesystemSupported: () => true,
+      getNotificationEnabled: () => false,
+      now: () => 15,
+      transport,
+    })
+
+    tracker.unsupportedInputFailed({
+      rawInput: '  DetailView.asp?ShopNo=1  ',
+      startedAt: 5,
+    })
+
+    expect(transport.trackUnsupportedInputFailure).toHaveBeenCalledWith({
+      batchId: 'batch-unsupported',
+      rawInput: '  DetailView.asp?ShopNo=1  ',
+      elapsedMs: 10,
+    })
+    expect(transport.trackBatchStarted).not.toHaveBeenCalled()
+  })
+
+  it('tracks preview start and completion using aggregate counts only', () => {
+    const transport = createTransport()
+    const tracker = createWorkflowAnalytics({
+      createBatchId: () => 'batch-preview',
+      getFilesystemSupported: () => true,
+      getNotificationEnabled: () => true,
+      now: () => 100,
+      transport,
+    })
+
+    const batch = tracker.previewStarted({ urlCount: 2, startedAt: 25 })
+
+    tracker.previewCompleted({
+      batch,
+      items: [
+        { id: 'listing-1', url: firstUrl, status: 'ready' },
+        {
+          id: 'listing-2',
+          url: `${firstUrl}&copy=2`,
+          status: 'failed',
+          message: '매물 이름을 확인하지 못했어요.',
+        },
+      ],
+    })
+
+    expect(transport.trackBatchStarted).toHaveBeenCalledWith(
+      expect.objectContaining({
+        batchId: 'batch-preview',
+        urlCount: 2,
+        uniqueUrlCount: 2,
+        readyCount: 0,
+      })
+    )
+    expect(transport.trackPreviewCompleted).toHaveBeenCalledWith(
+      expect.objectContaining({
+        batchId: 'batch-preview',
+        urlCount: 2,
+        uniqueUrlCount: 2,
+        readyCount: 1,
+        previewFailedCount: 1,
+        notificationEnabled: true,
+      })
+    )
+    expect(transport.trackListingFailed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        batchId: 'batch-preview',
+        failureStage: 'preview',
+        listingUrl: `${firstUrl}&copy=2`,
+      })
+    )
+  })
+
+  it('tracks save batches by original preview batch', () => {
+    const transport = createTransport()
+    const tracker = createWorkflowAnalytics({
+      createBatchId: () => 'batch-save',
+      getFilesystemSupported: () => true,
+      getNotificationEnabled: () => false,
+      now: () => 200,
+      transport,
+    })
+    const batch = tracker.previewStarted({ urlCount: 1, startedAt: 100 })
+
+    tracker.previewCompleted({
+      batch,
+      items: [{ id: 'listing-1', url: firstUrl, status: 'ready' }],
+    })
+    tracker.saveStarted({
+      items: [{ id: 'listing-1', url: firstUrl, listing }],
+      saveMethod: 'directory',
+    })
+    tracker.saveListingFailed({
+      item: { id: 'listing-1', url: firstUrl, listing },
+      message: '저장하지 못했어요.',
+    })
+    tracker.saveSettled({
+      items: [{ id: 'listing-1', url: firstUrl, listing }],
+      saveMethod: 'directory',
+      savedItemIds: new Set(),
+    })
+
+    expect(transport.trackSaveStarted).toHaveBeenCalledWith(
+      expect.objectContaining({
+        batchId: 'batch-save',
+        readyCount: 1,
+        saveMethod: 'directory',
+      })
+    )
+    expect(transport.trackListingFailed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        batchId: 'batch-save',
+        failureStage: 'save',
+        listingUrl: firstUrl,
+        vehicleNumber: '서울12가3456',
+        vehicleName: '현대 메가트럭',
+        imageCount: 1,
+      })
+    )
+    expect(transport.trackSaveFailed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        batchId: 'batch-save',
+        savedCount: 0,
+        saveFailedCount: 1,
+      })
+    )
+  })
+
+  it('removes listing analytics state when a chip is removed', () => {
+    const transport = createTransport()
+    const tracker = createWorkflowAnalytics({
+      createBatchId: () => 'batch-removed',
+      getFilesystemSupported: () => false,
+      getNotificationEnabled: () => false,
+      now: () => 300,
+      transport,
+    })
+    const batch = tracker.previewStarted({ urlCount: 1, startedAt: 250 })
+
+    tracker.previewCompleted({
+      batch,
+      items: [{ id: 'listing-1', url: firstUrl, status: 'ready' }],
+    })
+    tracker.removeListing('listing-1')
+    tracker.saveStarted({
+      items: [{ id: 'listing-1', url: firstUrl, listing }],
+      saveMethod: 'zip',
+    })
+
+    expect(transport.trackSaveStarted).toHaveBeenCalledWith(
+      expect.objectContaining({
+        batchId: expect.stringMatching(/^batch-/),
+        saveMethod: 'zip',
+      })
+    )
+  })
+})
+```
+
+- [ ] **Step 2: Run the analytics adapter tests to verify they fail**
+
+Run:
+
+```bash
+bun run test -- --run src/v2/application/truck-harvester-workflow/workflow-analytics.test.ts
+```
+
+Expected: FAIL because `workflow-analytics.ts` does not exist.
+
+- [ ] **Step 3: Implement workflow analytics types and factory**
+
+Create `src/v2/application/truck-harvester-workflow/workflow-analytics.ts`:
+
+```ts
+import {
+  createAnalyticsBatchId,
+  trackBatchStarted,
+  trackListingFailed,
+  trackPreviewCompleted,
+  trackSaveCompleted,
+  trackSaveFailed,
+  trackSaveStarted,
+  trackUnsupportedInputFailure,
+  type BatchAnalyticsInput,
+  type SaveMethod,
+} from '@/v2/shared/lib/analytics'
+import { type TruckListing } from '@/v2/entities/truck'
+
+export interface AnalyticsBatchRef {
+  id: string
+  startedAt: number
+  urlCount: number
+}
+
+export type WorkflowPreviewItem =
+  | { id: string; url: string; status: 'ready' }
+  | { id: string; url: string; status: 'failed' | 'invalid'; message: string }
+
+export interface WorkflowSaveItem {
+  id: string
+  url: string
+  listing: TruckListing
+}
+
+export interface WorkflowAnalyticsTransport {
+  trackBatchStarted: typeof trackBatchStarted
+  trackListingFailed: typeof trackListingFailed
+  trackPreviewCompleted: typeof trackPreviewCompleted
+  trackSaveCompleted: typeof trackSaveCompleted
+  trackSaveFailed: typeof trackSaveFailed
+  trackSaveStarted: typeof trackSaveStarted
+  trackUnsupportedInputFailure: typeof trackUnsupportedInputFailure
+}
+
+export interface WorkflowTracker {
+  unsupportedInputFailed: (event: { rawInput: string; startedAt: number }) => void
+  previewStarted: (event: { urlCount: number; startedAt: number }) => AnalyticsBatchRef
+  previewCompleted: (event: {
+    batch: AnalyticsBatchRef
+    items: readonly WorkflowPreviewItem[]
+  }) => void
+  saveStarted: (event: { items: readonly WorkflowSaveItem[]; saveMethod: SaveMethod }) => void
+  saveListingFailed: (event: { item: WorkflowSaveItem; message: string }) => void
+  saveSettled: (event: {
+    items: readonly WorkflowSaveItem[]
+    saveMethod: SaveMethod
+    savedItemIds: ReadonlySet<string>
+  }) => void
+  removeListing: (id: string) => void
+}
+
+interface CreateWorkflowAnalyticsInput {
+  createBatchId?: () => string
+  getFilesystemSupported: () => boolean
+  getNotificationEnabled: () => boolean
+  now?: () => number
+  transport?: WorkflowAnalyticsTransport
+}
+
+interface SaveBatchGroup {
+  batch: AnalyticsBatchRef
+  items: WorkflowSaveItem[]
+}
+
+const missingListingIdentityPlaceholder = '차명 정보 없음'
+
+const defaultTransport: WorkflowAnalyticsTransport = {
+  trackBatchStarted,
+  trackListingFailed,
+  trackPreviewCompleted,
+  trackSaveCompleted,
+  trackSaveFailed,
+  trackSaveStarted,
+  trackUnsupportedInputFailure,
+}
+
+const getDuration = (now: () => number, startedAt: number) =>
+  Math.max(0, Math.round(now() - startedAt))
+
+const isUsableListingIdentity = (value: string) => {
+  const trimmedValue = value.trim()
+
+  return trimmedValue.length > 0 && trimmedValue !== missingListingIdentityPlaceholder
+}
+
+const getSaveFailureVehicleName = (listing: TruckListing) =>
+  [listing.vname, listing.vehicleName].find(isUsableListingIdentity) ||
+  listing.vname ||
+  listing.vehicleName
+
+export function createWorkflowAnalytics({
+  createBatchId = createAnalyticsBatchId,
+  getFilesystemSupported,
+  getNotificationEnabled,
+  now = () => (typeof performance !== 'undefined' ? performance.now() : Date.now()),
+  transport = defaultTransport,
+}: CreateWorkflowAnalyticsInput): WorkflowTracker {
+  const batchByListingId = new Map<string, AnalyticsBatchRef>()
+  const saveFailureIds = new Set<string>()
+
+  const createBatch = (urlCount: number, startedAt: number): AnalyticsBatchRef => ({
+    id: createBatchId(),
+    startedAt,
+    urlCount,
+  })
+
+  const toBatchInput = (
+    batch: AnalyticsBatchRef,
+    items: readonly WorkflowPreviewItem[],
+    options: {
+      saveMethod?: SaveMethod
+      savedCount?: number
+      saveFailedCount?: number
+      uniqueUrlCount?: number
+    } = {}
+  ): BatchAnalyticsInput => ({
+    batchId: batch.id,
+    urlCount: batch.urlCount,
+    uniqueUrlCount: options.uniqueUrlCount ?? items.length,
+    readyCount: items.filter((item) => item.status === 'ready').length,
+    invalidCount: items.filter((item) => item.status === 'invalid').length,
+    previewFailedCount: items.filter((item) => item.status === 'failed').length,
+    savedCount: options.savedCount ?? 0,
+    saveFailedCount: options.saveFailedCount ?? 0,
+    durationMs: getDuration(now, batch.startedAt),
+    saveMethod: options.saveMethod,
+    filesystemSupported: getFilesystemSupported(),
+    notificationEnabled: getNotificationEnabled(),
+  })
+
+  const toReadyPreviewItems = (items: readonly WorkflowSaveItem[]): WorkflowPreviewItem[] =>
+    items.map((item) => ({ id: item.id, url: item.url, status: 'ready' }))
+
+  const ensureFallbackBatch = (items: readonly WorkflowSaveItem[]) => {
+    const missingItems = items.filter((item) => !batchByListingId.has(item.id))
+
+    if (missingItems.length === 0) {
+      return
+    }
+
+    const fallbackBatch = createBatch(missingItems.length, now())
+
+    missingItems.forEach((item) => {
+      batchByListingId.set(item.id, fallbackBatch)
+    })
+  }
+
+  const getSaveGroups = (items: readonly WorkflowSaveItem[]) => {
+    ensureFallbackBatch(items)
+
+    const groups: SaveBatchGroup[] = []
+    const groupByBatchId = new Map<string, SaveBatchGroup>()
+
+    items.forEach((item) => {
+      const batch = batchByListingId.get(item.id)
+
+      if (!batch) {
+        return
+      }
+
+      const currentGroup = groupByBatchId.get(batch.id)
+
+      if (currentGroup) {
+        currentGroup.items.push(item)
+        return
+      }
+
+      const nextGroup = { batch, items: [item] }
+      groupByBatchId.set(batch.id, nextGroup)
+      groups.push(nextGroup)
+    })
+
+    return groups
+  }
+
+  const getSaveCounts = (group: SaveBatchGroup, savedItemIds: ReadonlySet<string>) => ({
+    savedCount: group.items.filter((item) => savedItemIds.has(item.id)).length,
+    saveFailedCount: group.items.filter((item) => saveFailureIds.has(item.id)).length,
+  })
+
+  return {
+    unsupportedInputFailed: ({ rawInput, startedAt }) => {
+      transport.trackUnsupportedInputFailure({
+        batchId: createBatchId(),
+        rawInput,
+        elapsedMs: getDuration(now, startedAt),
+      })
+    },
+    previewStarted: ({ urlCount, startedAt }) => {
+      const batch = createBatch(urlCount, startedAt)
+
+      transport.trackBatchStarted(toBatchInput(batch, [], { uniqueUrlCount: urlCount }))
+
+      return batch
+    },
+    previewCompleted: ({ batch, items }) => {
+      items.forEach((item) => {
+        batchByListingId.set(item.id, batch)
+      })
+
+      transport.trackPreviewCompleted(toBatchInput(batch, items))
+
+      items.forEach((item) => {
+        if (item.status === 'ready') {
+          return
+        }
+
+        transport.trackListingFailed({
+          batchId: batch.id,
+          failureStage: item.status === 'invalid' ? 'invalid_url' : 'preview',
+          failureReason: item.message,
+          listingUrl: item.url,
+          elapsedMs: getDuration(now, batch.startedAt),
+        })
+      })
+    },
+    saveStarted: ({ items, saveMethod }) => {
+      getSaveGroups(items).forEach((group) => {
+        transport.trackSaveStarted(
+          toBatchInput(group.batch, toReadyPreviewItems(group.items), {
+            saveMethod,
+          })
+        )
+      })
+    },
+    saveListingFailed: ({ item, message }) => {
+      const batch = batchByListingId.get(item.id)
+
+      if (!batch) {
+        return
+      }
+
+      saveFailureIds.add(item.id)
+      transport.trackListingFailed({
+        batchId: batch.id,
+        failureStage: 'save',
+        failureReason: message,
+        listingUrl: item.url,
+        vehicleNumber: item.listing.vnumber,
+        vehicleName: getSaveFailureVehicleName(item.listing),
+        imageCount: item.listing.images.length,
+        elapsedMs: getDuration(now, batch.startedAt),
+      })
+    },
+    saveSettled: ({ items, saveMethod, savedItemIds }) => {
+      getSaveGroups(items).forEach((group) => {
+        const counts = getSaveCounts(group, savedItemIds)
+        const input = toBatchInput(group.batch, toReadyPreviewItems(group.items), {
+          ...counts,
+          saveMethod,
+        })
+
+        if (counts.savedCount === group.items.length) {
+          transport.trackSaveCompleted(input)
+          return
+        }
+
+        transport.trackSaveFailed(input)
+      })
+    },
+    removeListing: (id) => {
+      batchByListingId.delete(id)
+      saveFailureIds.delete(id)
+    },
+  }
+}
+```
+
+- [ ] **Step 4: Run the analytics adapter tests to verify they pass**
+
+Run:
+
+```bash
+bun run test -- --run src/v2/application/truck-harvester-workflow/workflow-analytics.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit analytics adapter**
+
+```bash
+git add src/v2/application/truck-harvester-workflow/workflow-analytics.ts src/v2/application/truck-harvester-workflow/workflow-analytics.test.ts
+git commit -m "refactor: workflow analytics adapter 추가"
+```
+
+## Task 4: Extract The Preview Workflow Use Case
+
+**Files:**
+
+- Create: `src/v2/application/truck-harvester-workflow/preview-workflow.ts`
+- Create: `src/v2/application/truck-harvester-workflow/preview-workflow.test.ts`
+
+- [ ] **Step 1: Write preview workflow tests**
+
+Create `src/v2/application/truck-harvester-workflow/preview-workflow.test.ts`:
+
+```ts
+import { type StoreApi } from 'zustand/vanilla'
+import { describe, expect, it, vi } from 'vitest'
+
+import { type TruckListing } from '@/v2/entities/truck'
+import {
+  createPreparedListingStore,
+  type PreparedListingState,
+} from '@/v2/features/listing-preparation'
+
+import { runPreviewWorkflow } from './preview-workflow'
+import { type AnalyticsBatchRef, type WorkflowTracker } from './workflow-analytics'
+
+const firstUrl = 'https://www.truck-no1.co.kr/model/DetailView.asp?ShopNo=1&MemberNo=2&OnCarNo=3'
+
+const listing: TruckListing = {
+  url: firstUrl,
+  vname: '현대 메가트럭',
+  vehicleName: '현대 메가트럭',
+  vnumber: '서울12가3456',
+  price: {
+    raw: 3200,
+    rawWon: 32000000,
+    label: '3,200만원',
+    compactLabel: '3,200만원',
+  },
+  year: '2020',
+  mileage: '120,000km',
+  options: '윙바디',
+  images: [],
+}
+
+const createTracker = () => {
+  const batch: AnalyticsBatchRef = {
+    id: 'batch-1',
+    startedAt: 10,
+    urlCount: 1,
+  }
+
+  return {
+    batch,
+    tracker: {
+      previewCompleted: vi.fn(),
+      previewStarted: vi.fn(() => batch),
+      removeListing: vi.fn(),
+      saveListingFailed: vi.fn(),
+      saveSettled: vi.fn(),
+      saveStarted: vi.fn(),
+      unsupportedInputFailed: vi.fn(),
+    } satisfies WorkflowTracker,
+  }
+}
+
+const runWorkflow = (input: {
+  text: string
+  store: StoreApi<PreparedListingState>
+  parse?: (url: string, signal?: AbortSignal) => Promise<TruckListing>
+  signal?: AbortSignal
+  tracker?: WorkflowTracker
+}) => {
+  const { tracker } = createTracker()
+
+  return runPreviewWorkflow({
+    getStartedAt: () => 10,
+    parse: input.parse ?? (async () => listing),
+    signal: input.signal,
+    store: input.store,
+    text: input.text,
+    tracker: input.tracker ?? tracker,
+  })
+}
+
+describe('runPreviewWorkflow', () => {
+  it('tracks unsupported non-empty input without starting preview', async () => {
+    const store = createPreparedListingStore()
+    const { tracker } = createTracker()
+
+    const result = await runWorkflow({
+      text: 'DetailView.asp?ShopNo=1',
+      store,
+      tracker,
+    })
+
+    expect(result).toEqual({
+      duplicateMessage: '매물 주소를 찾지 못했어요. 복사한 내용을 다시 확인해 주세요.',
+    })
+    expect(tracker.unsupportedInputFailed).toHaveBeenCalledWith({
+      rawInput: 'DetailView.asp?ShopNo=1',
+      startedAt: 10,
+    })
+    expect(tracker.previewStarted).not.toHaveBeenCalled()
+  })
+
+  it('does not track whitespace input', async () => {
+    const store = createPreparedListingStore()
+    const { tracker } = createTracker()
+
+    await runWorkflow({
+      text: ' \n\t ',
+      store,
+      tracker,
+    })
+
+    expect(tracker.unsupportedInputFailed).not.toHaveBeenCalled()
+    expect(tracker.previewStarted).not.toHaveBeenCalled()
+  })
+
+  it('adds supported URLs, previews them, and reports preview completion', async () => {
+    const store = createPreparedListingStore()
+    const { batch, tracker } = createTracker()
+
+    const result = await runWorkflow({
+      text: firstUrl,
+      store,
+      tracker,
+    })
+
+    expect(result).toEqual({ duplicateMessage: null })
+    expect(store.getState().items[0]).toMatchObject({
+      id: 'listing-1',
+      status: 'ready',
+      url: firstUrl,
+    })
+    expect(tracker.previewStarted).toHaveBeenCalledWith({
+      urlCount: 1,
+      startedAt: 10,
+    })
+    expect(tracker.previewCompleted).toHaveBeenCalledWith({
+      batch,
+      items: [{ id: 'listing-1', url: firstUrl, status: 'ready' }],
+    })
+  })
+
+  it('returns the duplicate helper message for duplicate pasted addresses', async () => {
+    const store = createPreparedListingStore()
+
+    await runWorkflow({ text: firstUrl, store })
+    const result = await runWorkflow({ text: firstUrl, store })
+
+    expect(result).toEqual({ duplicateMessage: '이미 넣은 매물이에요.' })
+  })
+
+  it('passes preview failures to workflow analytics', async () => {
+    const store = createPreparedListingStore()
+    const { tracker } = createTracker()
+
+    await runWorkflow({
+      text: firstUrl,
+      store,
+      tracker,
+      parse: async () => {
+        throw new Error('network failed')
+      },
+    })
+
+    expect(tracker.previewCompleted).toHaveBeenCalledWith(
+      expect.objectContaining({
+        items: [
+          {
+            id: 'listing-1',
+            message: '매물 이름을 확인하지 못했어요. 잠시 후 다시 붙여넣어 주세요.',
+            status: 'failed',
+            url: firstUrl,
+          },
+        ],
+      })
+    )
+  })
+})
+```
+
+- [ ] **Step 2: Run preview workflow tests to verify they fail**
+
+Run:
+
+```bash
+bun run test -- --run src/v2/application/truck-harvester-workflow/preview-workflow.test.ts
+```
+
+Expected: FAIL because `preview-workflow.ts` does not exist.
+
+- [ ] **Step 3: Implement `runPreviewWorkflow`**
+
+Create `src/v2/application/truck-harvester-workflow/preview-workflow.ts`:
+
+```ts
+import {
+  parseUrlInputText,
+  prepareListingUrls,
+  type PreparedListingSettledItem,
+  type PreparedListingState,
+} from '@/v2/features/listing-preparation'
+import { type TruckListing } from '@/v2/entities/truck'
+import { type StoreApi } from 'zustand/vanilla'
+
+import { type WorkflowPreviewItem, type WorkflowTracker } from './workflow-analytics'
+
+interface RunPreviewWorkflowInput {
+  getStartedAt?: () => number
+  parse?: (url: string, signal?: AbortSignal) => Promise<TruckListing>
+  signal?: AbortSignal
+  store: StoreApi<PreparedListingState>
+  text: string
+  tracker: WorkflowTracker
+}
+
+interface RunPreviewWorkflowResult {
+  duplicateMessage: string | null
+}
+
+const duplicateMessage = '이미 넣은 매물이에요.'
+
+const toWorkflowPreviewItem = (item: PreparedListingSettledItem): WorkflowPreviewItem => {
+  if (item.status === 'ready') {
+    return {
+      id: item.id,
+      url: item.url,
+      status: 'ready',
+    }
+  }
+
+  return {
+    id: item.id,
+    url: item.url,
+    status: item.status,
+    message: item.message,
+  }
+}
+
+export async function runPreviewWorkflow({
+  getStartedAt = () => (typeof performance !== 'undefined' ? performance.now() : Date.now()),
+  parse,
+  signal,
+  store,
+  text,
+  tracker,
+}: RunPreviewWorkflowInput): Promise<RunPreviewWorkflowResult> {
+  const startedAt = getStartedAt()
+  const input = parseUrlInputText(text)
+
+  if (!input.success) {
+    if (text.trim().length > 0) {
+      tracker.unsupportedInputFailed({
+        rawInput: text,
+        startedAt,
+      })
+    }
+
+    return { duplicateMessage: input.message }
+  }
+
+  const batch = tracker.previewStarted({
+    urlCount: input.urls.length,
+    startedAt,
+  })
+
+  const result = await prepareListingUrls({
+    urls: input.urls,
+    store,
+    signal,
+    parse,
+  })
+
+  tracker.previewCompleted({
+    batch,
+    items: result.settledItems.map(toWorkflowPreviewItem),
+  })
+
+  return {
+    duplicateMessage: result.duplicates.length > 0 ? duplicateMessage : null,
+  }
+}
+```
+
+- [ ] **Step 4: Run preview workflow tests to verify they pass**
+
+Run:
+
+```bash
+bun run test -- --run src/v2/application/truck-harvester-workflow/preview-workflow.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit preview workflow**
+
+```bash
+git add src/v2/application/truck-harvester-workflow/preview-workflow.ts src/v2/application/truck-harvester-workflow/preview-workflow.test.ts
+git commit -m "refactor: 미리보기 workflow use case 분리"
+```
+
+## Task 5: Extract The Save Workflow Use Case
+
+**Files:**
+
+- Create: `src/v2/application/truck-harvester-workflow/save-workflow.ts`
+- Create: `src/v2/application/truck-harvester-workflow/save-workflow.test.ts`
+
+- [ ] **Step 1: Write save workflow tests**
+
+Create `src/v2/application/truck-harvester-workflow/save-workflow.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from 'vitest'
+
+import { type TruckListing } from '@/v2/entities/truck'
+import {
+  createPreparedListingStore,
+  type ReadyPreparedListing,
+} from '@/v2/features/listing-preparation'
+
+import { runSaveWorkflow } from './save-workflow'
+import { type WorkflowTracker } from './workflow-analytics'
+
+const firstUrl = 'https://www.truck-no1.co.kr/model/DetailView.asp?ShopNo=1&MemberNo=2&OnCarNo=3'
+
+const listing: TruckListing = {
+  url: firstUrl,
+  vname: '현대 메가트럭',
+  vehicleName: '현대 메가트럭',
+  vnumber: '서울12가3456',
+  price: {
+    raw: 3200,
+    rawWon: 32000000,
+    label: '3,200만원',
+    compactLabel: '3,200만원',
+  },
+  year: '2020',
+  mileage: '120,000km',
+  options: '윙바디',
+  images: [],
+}
+
+const createReadyItem = (): ReadyPreparedListing => ({
+  status: 'ready',
+  id: 'listing-1',
+  url: firstUrl,
+  label: listing.vname,
+  listing,
+})
+
+const createTracker = (): WorkflowTracker => ({
+  previewCompleted: vi.fn(),
+  previewStarted: vi.fn(),
+  removeListing: vi.fn(),
+  saveListingFailed: vi.fn(),
+  saveSettled: vi.fn(),
+  saveStarted: vi.fn(),
+  unsupportedInputFailed: vi.fn(),
+})
+
+describe('runSaveWorkflow', () => {
+  it('saves ready listings to a directory and reports completion', async () => {
+    const store = createPreparedListingStore()
+    const item = createReadyItem()
+    const tracker = createTracker()
+
+    store.setState({ items: [item] })
+
+    const result = await runSaveWorkflow({
+      items: [item],
+      saveMethod: 'directory',
+      saveTruckToDirectory: vi.fn().mockResolvedValue(undefined),
+      store,
+      tracker,
+    })
+
+    expect(result).toEqual({ savedCount: 1 })
+    expect(store.getState().items[0]).toMatchObject({
+      status: 'saved',
+      id: 'listing-1',
+    })
+    expect(tracker.saveStarted).toHaveBeenCalledWith({
+      items: [{ id: 'listing-1', url: firstUrl, listing }],
+      saveMethod: 'directory',
+    })
+    expect(tracker.saveSettled).toHaveBeenCalledWith({
+      items: [{ id: 'listing-1', url: firstUrl, listing }],
+      saveMethod: 'directory',
+      savedItemIds: new Set(['listing-1']),
+    })
+  })
+
+  it('marks a directory save failure and keeps the workflow running', async () => {
+    const store = createPreparedListingStore()
+    const item = createReadyItem()
+    const tracker = createTracker()
+
+    store.setState({ items: [item] })
+
+    const result = await runSaveWorkflow({
+      items: [item],
+      saveMethod: 'directory',
+      saveTruckToDirectory: vi.fn().mockRejectedValue(new Error('disk full')),
+      store,
+      tracker,
+    })
+
+    expect(result).toEqual({ savedCount: 0 })
+    expect(store.getState().items[0]).toMatchObject({
+      status: 'failed',
+      message: '저장하지 못했어요. 저장 폴더와 인터넷 연결을 확인한 뒤 다시 시도해 주세요.',
+    })
+    expect(tracker.saveListingFailed).toHaveBeenCalledWith({
+      item: { id: 'listing-1', url: firstUrl, listing },
+      message: '저장하지 못했어요. 저장 폴더와 인터넷 연결을 확인한 뒤 다시 시도해 주세요.',
+    })
+  })
+
+  it('saves all ready listings through ZIP fallback', async () => {
+    const store = createPreparedListingStore()
+    const item = createReadyItem()
+    const tracker = createTracker()
+
+    store.setState({ items: [item] })
+
+    const result = await runSaveWorkflow({
+      downloadTruckZip: vi.fn().mockResolvedValue(undefined),
+      items: [item],
+      saveMethod: 'zip',
+      store,
+      tracker,
+    })
+
+    expect(result).toEqual({ savedCount: 1 })
+    expect(store.getState().items[0]).toMatchObject({ status: 'saved' })
+  })
+
+  it('marks all ready listings failed when ZIP fallback fails', async () => {
+    const store = createPreparedListingStore()
+    const item = createReadyItem()
+    const tracker = createTracker()
+
+    store.setState({ items: [item] })
+
+    const result = await runSaveWorkflow({
+      downloadTruckZip: vi.fn().mockRejectedValue(new Error('zip failed')),
+      items: [item],
+      saveMethod: 'zip',
+      store,
+      tracker,
+    })
+
+    expect(result).toEqual({ savedCount: 0 })
+    expect(store.getState().items[0]).toMatchObject({ status: 'failed' })
+    expect(tracker.saveListingFailed).toHaveBeenCalledWith({
+      item: { id: 'listing-1', url: firstUrl, listing },
+      message: '저장하지 못했어요. 저장 폴더와 인터넷 연결을 확인한 뒤 다시 시도해 주세요.',
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run save workflow tests to verify they fail**
+
+Run:
+
+```bash
+bun run test -- --run src/v2/application/truck-harvester-workflow/save-workflow.test.ts
+```
+
+Expected: FAIL because `save-workflow.ts` does not exist.
+
+- [ ] **Step 3: Implement `runSaveWorkflow`**
+
+Create `src/v2/application/truck-harvester-workflow/save-workflow.ts`:
+
+```ts
+import { type StoreApi } from 'zustand/vanilla'
+
+import {
+  downloadTruckZip as defaultDownloadTruckZip,
+  saveTruckToDirectory as defaultSaveTruckToDirectory,
+  type WritableDirectoryHandle,
+} from '@/v2/features/file-management'
+import {
+  type PreparedListingSaveProgress,
+  type PreparedListingState,
+  type ReadyPreparedListing,
+} from '@/v2/features/listing-preparation'
+import { type SaveMethod } from '@/v2/shared/lib/analytics'
+
+import { type WorkflowSaveItem, type WorkflowTracker } from './workflow-analytics'
+
+const saveFailureMessage =
+  '저장하지 못했어요. 저장 폴더와 인터넷 연결을 확인한 뒤 다시 시도해 주세요.'
+
+type SaveTruckToDirectory = typeof defaultSaveTruckToDirectory
+type DownloadTruckZip = typeof defaultDownloadTruckZip
+
+interface RunSaveWorkflowInput {
+  directory?: WritableDirectoryHandle | null
+  downloadTruckZip?: DownloadTruckZip
+  items: readonly ReadyPreparedListing[]
+  saveMethod: SaveMethod
+  saveTruckToDirectory?: SaveTruckToDirectory
+  signal?: AbortSignal
+  store: StoreApi<PreparedListingState>
+  tracker: WorkflowTracker
+}
+
+interface RunSaveWorkflowResult {
+  savedCount: number
+}
+
+const toWorkflowSaveItem = (item: ReadyPreparedListing): WorkflowSaveItem => ({
+  id: item.id,
+  url: item.url,
+  listing: item.listing,
+})
+
+const canContinue = (signal?: AbortSignal) => !signal?.aborted
+
+const markInitialSaving = (store: StoreApi<PreparedListingState>, item: ReadyPreparedListing) => {
+  store.getState().markSaving(item.id, {
+    downloadedImages: 0,
+    totalImages: item.listing.images.length,
+    progress: 0,
+  })
+}
+
+const markFailed = (store: StoreApi<PreparedListingState>, item: ReadyPreparedListing) => {
+  store.getState().markFailed(item.url, saveFailureMessage)
+}
+
+export async function runSaveWorkflow({
+  directory = null,
+  downloadTruckZip = defaultDownloadTruckZip,
+  items,
+  saveMethod,
+  saveTruckToDirectory = defaultSaveTruckToDirectory,
+  signal,
+  store,
+  tracker,
+}: RunSaveWorkflowInput): Promise<RunSaveWorkflowResult> {
+  const workflowItems = items.map(toWorkflowSaveItem)
+  const savedItemIds = new Set<string>()
+  let savedCount = 0
+
+  tracker.saveStarted({ items: workflowItems, saveMethod })
+
+  if (saveMethod === 'directory' && directory) {
+    for (const item of items) {
+      if (!canContinue(signal)) {
+        return { savedCount }
+      }
+
+      markInitialSaving(store, item)
+
+      try {
+        await saveTruckToDirectory(directory, item.listing, {
+          signal,
+          onProgress: (progress: number, downloadedImages: number, totalImages: number) => {
+            if (!canContinue(signal)) {
+              return
+            }
+
+            store.getState().markSaving(item.id, {
+              progress,
+              downloadedImages,
+              totalImages,
+            } satisfies PreparedListingSaveProgress)
+          },
+        })
+
+        if (!canContinue(signal)) {
+          return { savedCount }
+        }
+
+        store.getState().markSaved(item.id)
+        savedItemIds.add(item.id)
+        savedCount += 1
+      } catch {
+        if (!canContinue(signal)) {
+          return { savedCount }
+        }
+
+        tracker.saveListingFailed({
+          item: toWorkflowSaveItem(item),
+          message: saveFailureMessage,
+        })
+        markFailed(store, item)
+      }
+    }
+  } else {
+    items.forEach((item) => {
+      markInitialSaving(store, item)
+    })
+
+    try {
+      await downloadTruckZip(
+        items.map((item) => item.listing),
+        {
+          signal,
+          onProgress: (progress: number) => {
+            if (!canContinue(signal)) {
+              return
+            }
+
+            items.forEach((item) => {
+              store.getState().markSaving(item.id, {
+                progress,
+                downloadedImages: 0,
+                totalImages: item.listing.images.length,
+              })
+            })
+          },
+        }
+      )
+
+      if (!canContinue(signal)) {
+        return { savedCount }
+      }
+
+      items.forEach((item) => {
+        store.getState().markSaved(item.id)
+        savedItemIds.add(item.id)
+      })
+      savedCount = items.length
+    } catch {
+      if (!canContinue(signal)) {
+        return { savedCount }
+      }
+
+      items.forEach((item) => {
+        tracker.saveListingFailed({
+          item: toWorkflowSaveItem(item),
+          message: saveFailureMessage,
+        })
+        markFailed(store, item)
+      })
+    }
+  }
+
+  tracker.saveSettled({
+    items: workflowItems,
+    saveMethod,
+    savedItemIds,
+  })
+
+  return { savedCount }
+}
+```
+
+- [ ] **Step 4: Run save workflow tests to verify they pass**
+
+Run:
+
+```bash
+bun run test -- --run src/v2/application/truck-harvester-workflow/save-workflow.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit save workflow**
+
+```bash
+git add src/v2/application/truck-harvester-workflow/save-workflow.ts src/v2/application/truck-harvester-workflow/save-workflow.test.ts
+git commit -m "refactor: 저장 workflow use case 분리"
+```
+
+## Task 6: Add The React Workflow Hook
+
+**Files:**
+
+- Create: `src/v2/application/truck-harvester-workflow/use-truck-harvester-workflow.ts`
+- Modify: `src/v2/application/truck-harvester-workflow/index.ts`
+
+- [ ] **Step 1: Write the hook export before implementation**
+
+Replace `src/v2/application/truck-harvester-workflow/index.ts`:
+
+```ts
+export * from './use-truck-harvester-workflow'
+```
+
+- [ ] **Step 2: Implement the workflow hook**
+
+Create `src/v2/application/truck-harvester-workflow/use-truck-harvester-workflow.ts`:
+
+```ts
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+
+import { useStore } from 'zustand'
+
+import {
+  isCompletionNotificationAvailable,
+  notifyCompletion,
+  requestCompletionNotificationPermission,
+} from '@/v2/features/completion-notification'
+import {
+  isFileSystemAccessAvailable,
+  pickWritableDirectory,
+  requestWritableDirectoryPermission,
+  type WritableDirectoryHandle,
+} from '@/v2/features/file-management'
+import {
+  createPreparedListingStore,
+  selectCheckingPreparedListings,
+  selectReadyPreparedListings,
+  type PreparedListing,
+} from '@/v2/features/listing-preparation'
+import { createOnboardingStore } from '@/v2/shared/model'
+import { type SaveMethod } from '@/v2/shared/lib/analytics'
+
+import { runPreviewWorkflow } from './preview-workflow'
+import { runSaveWorkflow } from './save-workflow'
+import { createWorkflowAnalytics } from './workflow-analytics'
+
+const saveFolderPickerId = 'truck-harvester-v2-save-folder'
+const useBrowserLayoutEffect = typeof window === 'undefined' ? useEffect : useLayoutEffect
+
+type DirectoryPermissionState = 'denied' | 'ready'
+type DirectoryPickerStartIn = WritableDirectoryHandle | 'downloads'
+
+const pickSaveDirectory = pickWritableDirectory as (options: {
+  id: string
+  startIn: DirectoryPickerStartIn
+}) => Promise<WritableDirectoryHandle | undefined>
+
+const requestNextFrame = (callback: () => void) => {
+  if (typeof window.requestAnimationFrame === 'function') {
+    return window.requestAnimationFrame(callback)
+  }
+
+  return window.setTimeout(callback, 16)
+}
+
+const cancelNextFrame = (handle: number) => {
+  if (typeof window.cancelAnimationFrame === 'function') {
+    window.cancelAnimationFrame(handle)
+    return
+  }
+
+  window.clearTimeout(handle)
+}
+
+const getNow = () => (typeof performance !== 'undefined' ? performance.now() : Date.now())
+
+const isNotificationEnabled = (permission: NotificationPermission | 'unsupported') =>
+  permission === 'granted'
+
+export function useTruckHarvesterWorkflow() {
+  const [preparedStore] = useState(() => createPreparedListingStore())
+  const [onboardingStore] = useState(() => createOnboardingStore({ deferInitialTour: true }))
+  const [directory, setDirectory] = useState<WritableDirectoryHandle | null>(null)
+  const [directoryPermissionState, setDirectoryPermissionState] =
+    useState<DirectoryPermissionState>('ready')
+  const [duplicateMessage, setDuplicateMessage] = useState<string | null>(null)
+  const [fileSystemSupported, setFileSystemSupported] = useState(false)
+  const [isSaving, setIsSaving] = useState(false)
+  const [notificationAvailable, setNotificationAvailable] = useState(false)
+  const [notificationPermission, setNotificationPermission] = useState<
+    NotificationPermission | 'unsupported'
+  >('unsupported')
+  const isMountedRef = useRef(false)
+  const pasteSequenceRef = useRef(0)
+  const previewControllersRef = useRef<Set<AbortController>>(new Set())
+  const saveControllerRef = useRef<AbortController | null>(null)
+  const fileSystemSupportedRef = useRef(false)
+  const notificationEnabledRef = useRef(false)
+  const [tracker] = useState(() =>
+    createWorkflowAnalytics({
+      getFilesystemSupported: () => fileSystemSupportedRef.current,
+      getNotificationEnabled: () => notificationEnabledRef.current,
+    })
+  )
+
+  const preparedState = useStore(preparedStore, (state) => state)
+  const onboardingState = useStore(onboardingStore, (state) => state)
+  const readyListings = selectReadyPreparedListings(preparedState)
+  const checkingListings = selectCheckingPreparedListings(preparedState)
+  const inputListings = preparedState.items.filter((item) => item.status !== 'saved')
+  const isTourOpen = onboardingState.isTourOpen
+  fileSystemSupportedRef.current = fileSystemSupported
+  notificationEnabledRef.current = isNotificationEnabled(notificationPermission)
+
+  useBrowserLayoutEffect(() => {
+    const supported = isFileSystemAccessAvailable()
+    setFileSystemSupported(supported)
+    setDirectoryPermissionState('ready')
+
+    if (isCompletionNotificationAvailable()) {
+      setNotificationAvailable(true)
+      setNotificationPermission(window.Notification.permission)
+    }
+
+    const frame = requestNextFrame(() => {
+      onboardingStore.getState().initializeTour()
+    })
+
+    return () => {
+      cancelNextFrame(frame)
+    }
+  }, [onboardingStore])
+
+  useEffect(() => {
+    isMountedRef.current = true
+    const previewControllers = previewControllersRef.current
+
+    return () => {
+      isMountedRef.current = false
+      previewControllers.forEach((controller) => controller.abort())
+      previewControllers.clear()
+      saveControllerRef.current?.abort()
+      saveControllerRef.current = null
+    }
+  }, [])
+
+  const resolveSaveDirectoryForRun = async () => {
+    if (!isFileSystemAccessAvailable()) {
+      return null
+    }
+
+    const activeDirectory = directory
+
+    if (activeDirectory) {
+      if (directoryPermissionState === 'denied') {
+        const nextDirectory = await pickSaveDirectory({
+          id: saveFolderPickerId,
+          startIn: 'downloads',
+        })
+
+        if (!nextDirectory) {
+          return undefined
+        }
+
+        if (isMountedRef.current) {
+          setDirectory(nextDirectory)
+          setDirectoryPermissionState('ready')
+        }
+
+        return nextDirectory
+      }
+
+      const hasPermission = await requestWritableDirectoryPermission(activeDirectory)
+
+      if (!hasPermission) {
+        if (isMountedRef.current) {
+          setDirectoryPermissionState('denied')
+        }
+        return undefined
+      }
+
+      if (isMountedRef.current) {
+        setDirectory(activeDirectory)
+        setDirectoryPermissionState('ready')
+      }
+
+      return activeDirectory
+    }
+
+    const nextDirectory = await pickSaveDirectory({
+      id: saveFolderPickerId,
+      startIn: 'downloads',
+    })
+
+    if (!nextDirectory) {
+      return undefined
+    }
+
+    if (isMountedRef.current) {
+      setDirectory(nextDirectory)
+      setDirectoryPermissionState('ready')
+    }
+
+    return nextDirectory
+  }
+
+  const selectDirectory = async (nextDirectory: WritableDirectoryHandle) => {
+    if (isMountedRef.current) {
+      setDirectory(nextDirectory)
+      setDirectoryPermissionState('ready')
+    }
+  }
+
+  const handlePasteText = (text: string) => {
+    const pasteSequence = pasteSequenceRef.current + 1
+    pasteSequenceRef.current = pasteSequence
+    const previewController = new AbortController()
+    previewControllersRef.current.add(previewController)
+
+    void runPreviewWorkflow({
+      getStartedAt: getNow,
+      signal: previewController.signal,
+      store: preparedStore,
+      text,
+      tracker,
+    })
+      .then((result) => {
+        if (!isMountedRef.current || previewController.signal.aborted) {
+          return
+        }
+
+        if (pasteSequenceRef.current === pasteSequence) {
+          setDuplicateMessage(result.duplicateMessage)
+        }
+      })
+      .catch(() => {
+        // Preview cancellation is expected when leaving the route.
+      })
+      .finally(() => {
+        previewControllersRef.current.delete(previewController)
+      })
+  }
+
+  const requestNotificationPermission = () => {
+    void requestCompletionNotificationPermission().then((permission) => {
+      if (isMountedRef.current) {
+        setNotificationPermission(permission)
+      }
+    })
+  }
+
+  const startSavingReadyListings = async () => {
+    if (isSaving || readyListings.length === 0 || checkingListings.length > 0) {
+      return
+    }
+
+    const controller = new AbortController()
+    saveControllerRef.current?.abort()
+    saveControllerRef.current = controller
+
+    try {
+      const runDirectory = await resolveSaveDirectoryForRun()
+
+      if (!isMountedRef.current || controller.signal.aborted) {
+        return
+      }
+
+      if (runDirectory === undefined) {
+        return
+      }
+
+      const saveMethod: SaveMethod = runDirectory ? 'directory' : 'zip'
+      const itemsToSave = readyListings
+      setIsSaving(true)
+
+      const result = await runSaveWorkflow({
+        directory: runDirectory,
+        items: itemsToSave,
+        saveMethod,
+        signal: controller.signal,
+        store: preparedStore,
+        tracker,
+      })
+
+      if (result.savedCount > 0 && isMountedRef.current) {
+        notifyCompletion(result.savedCount)
+      }
+    } finally {
+      if (saveControllerRef.current === controller) {
+        saveControllerRef.current = null
+      }
+
+      if (isMountedRef.current) {
+        setIsSaving(false)
+      }
+    }
+  }
+
+  const removePreparedItem = (id: string) => {
+    tracker.removeListing(id)
+    preparedStore.getState().remove(id)
+  }
+
+  const canRemovePreparedItem = (item: PreparedListing) =>
+    item.status !== 'saving' && item.status !== 'saved'
+
+  return {
+    canRemovePreparedItem,
+    directory,
+    directoryPermissionState,
+    duplicateMessage,
+    fileSystemSupported,
+    handlePasteText,
+    inputListings,
+    isSaving,
+    isTourOpen,
+    notificationAvailable,
+    notificationPermission,
+    onboardingState,
+    preparedItems: preparedState.items,
+    pickerStartIn: directoryPermissionState === 'denied' ? 'downloads' : (directory ?? 'downloads'),
+    removePreparedItem,
+    requestNotificationPermission,
+    selectDirectory,
+    startSavingReadyListings,
+  }
+}
+```
+
+- [ ] **Step 3: Run typecheck to catch hook boundary errors**
+
+Run:
+
+```bash
+bun run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit workflow hook**
+
+```bash
+git add src/v2/application/truck-harvester-workflow/use-truck-harvester-workflow.ts src/v2/application/truck-harvester-workflow/index.ts
+git commit -m "refactor: root workflow hook 추가"
+```
+
+## Task 7: Slim The Root App Composition
+
+**Files:**
+
+- Modify: `src/app/truck-harvester-app.tsx`
+- Modify: `src/app/__tests__/truck-harvester-app.test.tsx`
+
+- [ ] **Step 1: Update the app test mocks to target the application boundary**
+
+In `src/app/__tests__/truck-harvester-app.test.tsx`, keep the existing UI helper functions. Replace the analytics mock assertions in route-level tests with UI outcome assertions for these cases:
+
+```ts
+expect(container?.textContent).toContain(
+  '매물 주소를 찾지 못했어요. 복사한 내용을 다시 확인해 주세요.'
+)
+expect(listingPreparationMocks.prepareListingUrls).not.toHaveBeenCalled()
+```
+
+For save success, keep:
+
+```ts
+expect(statusRegion?.textContent).toContain('저장 완료')
+expect(inputRegion?.textContent).not.toContain('현대 메가트럭')
+```
+
+Move payload-specific expectations for `trackBatchStarted`,
+`trackPreviewCompleted`, `trackListingFailed`, `trackSaveStarted`,
+`trackSaveCompleted`, and `trackSaveFailed` out of route tests because
+`workflow-analytics.test.ts` owns them.
+
+- [ ] **Step 2: Run the route test to verify the old root implementation still passes before slimming**
+
+Run:
+
+```bash
+bun run test -- --run src/app/__tests__/truck-harvester-app.test.tsx
+```
+
+Expected: PASS before the component is slimmed.
+
+- [ ] **Step 3: Replace root orchestration with the workflow hook**
+
+Replace `src/app/truck-harvester-app.tsx` with:
+
+```tsx
+'use client'
+
+import { CompletionNotificationToggle } from '@/v2/features/completion-notification'
+import { HelpMenuButton, TourOverlay, tourSteps } from '@/v2/features/onboarding'
+import { useTruckHarvesterWorkflow } from '@/v2/application'
+import { DirectorySelector } from '@/v2/widgets/directory-selector'
+import { PreparedListingStatusPanel } from '@/v2/widgets/processing-status'
+import { ListingChipInput } from '@/v2/widgets/url-input'
+
+export function TruckHarvesterApp() {
+  const workflow = useTruckHarvesterWorkflow()
+
+  return (
+    <main className="bg-background text-foreground min-h-dvh" data-tour="v2-page">
+      <section
+        className="mx-auto grid min-h-dvh w-full max-w-6xl gap-6 px-6 py-8 md:px-10"
+        data-tour-background="true"
+        inert={workflow.isTourOpen ? true : undefined}
+      >
+        <header className="flex items-center justify-between gap-4">
+          <div>
+            <p className="text-muted-foreground text-sm font-medium">새 작업 화면</p>
+            <h1 className="text-foreground text-2xl font-semibold tracking-normal">
+              트럭 매물 수집기
+            </h1>
+          </div>
+          <HelpMenuButton
+            disabled={workflow.isTourOpen}
+            onRestartTour={workflow.onboardingState.restartTour}
+          />
+        </header>
+
+        <div className="grid gap-5 lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]">
+          <div className="grid content-start gap-5">
+            <div data-tour="url-input">
+              <ListingChipInput
+                canRemoveItem={workflow.canRemovePreparedItem}
+                disabled={workflow.isSaving || workflow.isTourOpen}
+                duplicateMessage={workflow.duplicateMessage}
+                items={workflow.inputListings}
+                onPasteText={workflow.handlePasteText}
+                onRemove={workflow.removePreparedItem}
+                onStart={() => void workflow.startSavingReadyListings()}
+              />
+            </div>
+          </div>
+
+          <div className="grid content-start gap-5">
+            <DirectorySelector
+              disabled={workflow.isTourOpen}
+              isSupported={workflow.fileSystemSupported}
+              onSelectDirectory={workflow.selectDirectory}
+              permissionState={workflow.directoryPermissionState}
+              pickerStartIn={workflow.pickerStartIn}
+              selectedDirectoryName={workflow.directory?.name}
+            />
+            <CompletionNotificationToggle
+              disabled={workflow.isTourOpen}
+              isAvailable={workflow.notificationAvailable}
+              onEnable={workflow.requestNotificationPermission}
+              permission={workflow.notificationPermission}
+            />
+            <div data-tour="processing-status">
+              <PreparedListingStatusPanel items={workflow.preparedItems} />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <TourOverlay
+        currentStep={workflow.onboardingState.currentStep}
+        isOpen={workflow.onboardingState.isTourOpen}
+        onClose={workflow.onboardingState.completeTour}
+        onNext={() => workflow.onboardingState.goToNextStep(tourSteps.length)}
+        onPrevious={workflow.onboardingState.goToPreviousStep}
+      />
+    </main>
+  )
+}
+```
+
+- [ ] **Step 4: Run root app and application tests**
+
+Run:
+
+```bash
+bun run test -- --run src/app/__tests__/truck-harvester-app.test.tsx src/v2/application/truck-harvester-workflow
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit root composition slimming**
+
+```bash
+git add src/app/truck-harvester-app.tsx src/app/__tests__/truck-harvester-app.test.tsx
+git commit -m "refactor: root 앱 workflow composition 축소"
+```
+
+## Task 8: Document The New Workflow Boundary
+
+**Files:**
+
+- Modify: `docs/architecture.md`
+- Modify: `docs/superpowers/specs/2026-04-30-business-tracking-separation-design.md`
+
+- [ ] **Step 1: Update architecture layer responsibilities**
+
+Modify the `Layer Responsibilities` section in `docs/architecture.md`:
+
+```md
+- `src/app`: root route composition, page layout, and widget wiring.
+- `src/v2/application`: root app workflow orchestration, React hook adapters,
+  and workflow analytics boundaries.
+- `src/v2/widgets`: user-facing blocks that compose features and shared
+  selectors.
+- `src/v2/features`: capabilities such as listing preparation, parsing,
+  saving, completion notifications, and onboarding.
+- `src/v2/entities`: pure schemas and state contracts.
+- `src/v2/shared`: utilities, stores, selectors, analytics transport, and
+  low-level UI.
+- `src/v2/design-system`: tokens and motion presets for the root app.
+```
+
+Add this paragraph after the Umami analytics paragraph:
+
+```md
+The application workflow layer emits business facts to a workflow analytics
+adapter. The route component and widgets do not assemble Umami payloads, and
+preview/save use cases do not call `window.umami` directly. The shared
+analytics transport remains the only layer that knows the concrete Umami event
+names and payload keys.
+```
+
+- [ ] **Step 2: Mark implementation plan linkage in the approved spec**
+
+Add this section near the end of `docs/superpowers/specs/2026-04-30-business-tracking-separation-design.md`:
+
+```md
+## Implementation Plan
+
+Execution plan: `docs/superpowers/plans/2026-04-30-business-tracking-separation.md`
+```
+
+- [ ] **Step 3: Run documentation tests and formatting for changed docs**
+
+Run:
+
+```bash
+bun run test -- --run src/v2/testing/__tests__/knowledge-base.test.ts
+bun prettier --check docs/architecture.md docs/superpowers/specs/2026-04-30-business-tracking-separation-design.md
+```
+
+Expected: both commands PASS.
+
+- [ ] **Step 4: Commit documentation updates**
+
+```bash
+git add docs/architecture.md docs/superpowers/specs/2026-04-30-business-tracking-separation-design.md
+git commit -m "docs: application workflow 경계 문서화"
+```
+
+## Task 9: Final Verification
+
+**Files:**
+
+- Verify only.
+
+- [ ] **Step 1: Run focused unit tests**
+
+Run:
+
+```bash
+bun run test -- --run src/v2/application/truck-harvester-workflow src/v2/features/listing-preparation/model/__tests__/url-input-parser.test.ts src/v2/widgets/url-input/model/__tests__/url-input-schema.test.ts src/app/__tests__/truck-harvester-app.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run typecheck**
+
+Run:
+
+```bash
+bun run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run lint**
+
+Run:
+
+```bash
+bun run lint
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run finite unit suite**
+
+Run:
+
+```bash
+bun run test -- --run
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run format check and record known unrelated warnings**
+
+Run:
+
+```bash
+bun run format:check
+```
+
+Expected after this refactor: PASS. If it reports only the pre-existing
+`src/app/apple-icon.tsx`, `src/app/icon.tsx`, and `src/app/opengraph-image.tsx`
+warnings seen before this plan, record that in the final report and do not
+silently reformat those unrelated files inside this refactor.
+
+- [ ] **Step 6: Inspect final diff**
+
+Run:
+
+```bash
+git status --short
+git diff --stat origin/main..HEAD
+git log --oneline origin/main..HEAD
+```
+
+Expected: working tree clean after commits; history shows focused refactor and docs commits.
+
+- [ ] **Step 7: Prepare final implementation summary**
+
+Report:
+
+```md
+Implemented application workflow separation.
+
+Key commits:
+
+- <hash> refactor: 입력 주소 파서 feature 계층 이동
+- <hash> refactor: workflow analytics adapter 추가
+- <hash> refactor: 미리보기 workflow use case 분리
+- <hash> refactor: 저장 workflow use case 분리
+- <hash> refactor: root workflow hook 추가
+- <hash> refactor: root 앱 workflow composition 축소
+- <hash> docs: application workflow 경계 문서화
+
+Verification:
+
+- bun run test -- --run ...
+- bun run typecheck
+- bun run lint
+- bun run test -- --run
+- bun run format:check
+```

--- a/docs/superpowers/specs/2026-04-30-business-tracking-separation-design.md
+++ b/docs/superpowers/specs/2026-04-30-business-tracking-separation-design.md
@@ -250,6 +250,10 @@ ListingChipInput start button
   규칙을 둔다.
 - 필요하면 `docs/runbooks/`에 workflow 변경 시 만질 위치를 추가한다.
 
+## Implementation Plan
+
+Execution plan: `docs/superpowers/plans/2026-04-30-business-tracking-separation.md`
+
 ## 수용 기준
 
 - `truck-harvester-app.tsx`는 analytics wrapper를 직접 import하지 않는다.

--- a/docs/superpowers/specs/2026-04-30-business-tracking-separation-design.md
+++ b/docs/superpowers/specs/2026-04-30-business-tracking-separation-design.md
@@ -1,0 +1,271 @@
+# 비즈니스 로직과 트래킹 로직 분리 설계
+
+작성일: 2026-04-30
+
+## 배경
+
+Truck Harvester의 현재 root app은 `src/app/truck-harvester-app.tsx`에서
+화면 조립, 붙여넣기 처리, 미리보기 실행, 저장 실행, 폴더 권한, 알림,
+Umami 트래킹 배치 매핑을 함께 담당한다. 이 구조는 동작은 명확하지만, 작은
+변경도 route composition 파일을 함께 읽어야 해서 비즈니스 흐름과 트래킹 흐름의
+경계가 흐려진다.
+
+이번 설계는 React 컴포넌트가 상태와 작업을 가까이 관리하되, 재사용 가능한
+비즈니스 흐름과 횡단 관심사인 트래킹은 별도 계층으로 분리한다. 참고한 컴포넌트
+설계 관점처럼 UI 컴포넌트는 사용자 제스처와 렌더링에 집중하고, 업무 규칙과
+트래킹 확장은 잘 정의된 인터페이스를 통해 연결한다.
+
+## 목표
+
+- root app 컴포넌트에서 비즈니스 use case와 analytics payload 조립을 제거한다.
+- `src/v2/application/` 계층을 도입해 paste-preview-save 흐름을 명시적으로
+  소유한다.
+- preview/save 업무 흐름은 가능한 한 React 밖에서 테스트 가능한 순수
+  TypeScript use case로 둔다.
+- React hook은 mount guard, `AbortController`, local UI state, 브라우저 권한
+  연결만 담당한다.
+- 트래킹은 workflow fact를 Umami 이벤트로 변환하는 adapter로 분리한다.
+- 기존 사용자 흐름, 한국어 문구, Umami 수집 범위, 기본 concurrency 5는
+  유지한다.
+
+## 비목표
+
+- UI 레이아웃이나 화면 문구를 재설계하지 않는다.
+- Umami 이벤트 계약 자체를 확장하지 않는다.
+- 외부 에러 모니터링 SDK, 이미지 스탬핑, 서버 주도 streaming을 추가하지 않는다.
+- 기존 `features/*` 능력 계층을 application 내부로 옮기지 않는다.
+- 저장 폴더 영구 보관 정책을 바꾸지 않는다.
+
+## 확정 접근
+
+접근은 새 application 계층을 둔 혼합형으로 확정한다.
+
+- 업무 흐름은 순수 use case에 둔다.
+- React 생명주기와 브라우저 접점은 얇은 custom hook에 둔다.
+- 트래킹은 업무 흐름을 관찰하는 adapter 포트로 둔다.
+
+이 방식은 기존 FSD 스타일을 유지하면서도 route composition과 feature primitive
+사이에 "앱 흐름" 계층을 명확히 만든다.
+
+## 새 계층 구조
+
+```txt
+src/v2/application/
+  AGENTS.md
+  truck-harvester-workflow/
+    index.ts
+    preview-workflow.ts
+    save-workflow.ts
+    use-truck-harvester-workflow.ts
+    workflow-analytics.ts
+```
+
+`src/v2/application`은 사용자가 root app에서 수행하는 업무 흐름을 소유한다.
+이 계층은 `features`, `entities`, `shared`를 사용할 수 있지만 `widgets`를
+import하지 않는다.
+
+## 계층별 책임
+
+### `src/app/truck-harvester-app.tsx`
+
+root app은 화면 조립만 담당한다.
+
+- workflow hook을 생성한다.
+- widget props에 상태와 command를 연결한다.
+- 사용자 제스처를 workflow command로 전달한다.
+- analytics 함수나 batch id를 직접 import하지 않는다.
+- preview/save 세부 진행 규칙을 직접 계산하지 않는다.
+
+예상 사용 형태:
+
+```ts
+const workflow = useTruckHarvesterWorkflow()
+
+workflow.handlePasteText(text)
+workflow.startSavingReadyListings()
+workflow.selectDirectory(directory)
+workflow.removePreparedItem(id)
+```
+
+### `use-truck-harvester-workflow.ts`
+
+React hook은 route composition을 얇게 유지하는 adapter다.
+
+- prepared listing store와 onboarding store를 생성한다.
+- `isMountedRef`, paste sequence, preview/save abort controller를 관리한다.
+- 파일 시스템 지원 여부, 선택 폴더, 권한 상태, 알림 권한 같은 UI state를
+  관리한다.
+- preview/save use case를 호출하고 화면에 필요한 command를 반환한다.
+- workflow tracker 인스턴스를 생성해 use case에 주입한다.
+
+### `preview-workflow.ts`
+
+preview use case는 붙여넣기부터 매물 확인 완료까지의 업무 규칙을 소유한다.
+
+- `parseUrlInputText` 결과를 받아 지원 주소 여부를 판단한다.
+- 지원하지 않는 비어 있지 않은 입력 fact를 tracker에 알린다.
+- 지원 주소가 있으면 analytics batch를 시작한다.
+- `prepareListingUrls`를 호출해 prepared listing store를 갱신한다.
+- preview 완료 fact와 listing failure fact를 tracker에 알린다.
+- duplicate helper message를 반환한다.
+- Umami 이벤트명, payload 필드명, `window.umami`를 모른다.
+
+### `save-workflow.ts`
+
+save use case는 ready listing 저장 흐름을 소유한다.
+
+- 저장 대상 ready listing을 고정한다.
+- directory 저장과 ZIP fallback 경로를 실행한다.
+- prepared listing store의 saving/saved/failed 상태 전환을 수행한다.
+- 저장 실패한 listing fact와 batch-level save fact를 tracker에 알린다.
+- 성공 저장 수를 반환해 hook이 완료 알림을 보낼 수 있게 한다.
+- 폴더 선택 UI나 권한 prompt 자체는 hook이 해결한 값으로 주입받는다.
+
+### `workflow-analytics.ts`
+
+workflow analytics는 업무 fact를 기존 Umami transport로 변환한다.
+
+- batch id 생성과 listing id -> batch 매핑을 소유한다.
+- preview/save batch group 계산을 소유한다.
+- `trackBatchStarted`, `trackPreviewCompleted`, `trackSaveStarted`,
+  `trackSaveCompleted`, `trackSaveFailed`, `trackListingFailed`,
+  `trackUnsupportedInputFailure` 호출을 캡슐화한다.
+- 실패 매물에만 URL, 차량번호, 차명, 이미지 수를 포함하는 기존 정책을 유지한다.
+- prepared listing store를 직접 mutate하지 않는다.
+
+## 트래킹 포트
+
+use case는 구체 Umami wrapper 대신 `WorkflowTracker` 포트에 업무 사실을 알린다.
+
+```ts
+interface WorkflowTracker {
+  unsupportedInputFailed(event: UnsupportedInputFailedFact): void
+  previewStarted(event: PreviewStartedFact): AnalyticsBatchRef
+  previewCompleted(event: PreviewCompletedFact): void
+  listingFailed(event: ListingFailedFact): void
+  saveStarted(event: SaveStartedFact): void
+  saveCompleted(event: SaveCompletedFact): void
+  saveFailed(event: SaveFailedFact): void
+  removeListing(id: string): void
+}
+```
+
+포트의 입력은 업무 언어를 사용한다. `batch_id`, `failure_stage`,
+`listing_url`, `vehicle_number`, `save_method` 같은 Umami 계약 필드는
+`workflow-analytics.ts` 내부에서만 다룬다.
+
+## 데이터 흐름
+
+붙여넣기 흐름:
+
+```txt
+ListingChipInput
+  -> useTruckHarvesterWorkflow.handlePasteText(text)
+  -> preview-workflow parses supported addresses
+  -> listing-preparation store adds/checks/marks items
+  -> workflow-analytics receives preview facts
+  -> shared analytics wrapper sends Umami events safely
+```
+
+저장 흐름:
+
+```txt
+ListingChipInput start button
+  -> useTruckHarvesterWorkflow.startSavingReadyListings()
+  -> hook resolves directory permission or ZIP fallback
+  -> save-workflow saves ready listings
+  -> listing-preparation store marks saving/saved/failed
+  -> workflow-analytics receives save facts
+  -> completion notification fires after successful saved count
+```
+
+## 의존성 규칙
+
+- `src/app`은 `src/v2/application`, `features`, `widgets`, `shared/model`을
+  조립할 수 있다.
+- `src/v2/application`은 `entities`, `features`, `shared`를 import할 수 있다.
+- `src/v2/application`은 `widgets`를 import하지 않는다.
+- `features`는 `application`을 import하지 않는다.
+- `widgets`는 tracking 함수를 import하지 않는다.
+- `shared/lib/analytics.ts`는 Umami transport와 payload builder로 남고, app
+  workflow 상태를 알지 않는다.
+
+## 마이그레이션 계획
+
+1. `src/v2/application/AGENTS.md`와 workflow slice public API를 만든다.
+2. `workflow-analytics.ts`를 추가해 현재 root app의 analytics batch helper와
+   tracking 호출을 옮긴다.
+3. `preview-workflow.ts`를 추가해 `handlePasteText`의 파싱, preview, duplicate
+   message, preview tracking 결정을 옮긴다.
+4. `save-workflow.ts`를 추가해 저장 루프와 save tracking 결정을 옮긴다.
+5. `use-truck-harvester-workflow.ts`를 추가해 React state, mount guard, abort,
+   directory/notification 연결을 소유하게 한다.
+6. `truck-harvester-app.tsx`를 workflow hook 기반으로 축소한다.
+7. architecture 문서와 layer AGENTS 문서를 갱신한다.
+
+각 단계는 기존 동작을 유지해야 하며, UI 문구 변경은 별도 의도가 있을 때만
+허용한다.
+
+## 테스트 계획
+
+### `preview-workflow.test.ts`
+
+- 지원 주소 붙여넣기에서 batch started와 preview completed fact가 발생한다.
+- 지원하지 않는 비어 있지 않은 입력은 unsupported input fact만 발생한다.
+- 공백 입력은 tracking fact를 만들지 않는다.
+- duplicate 주소는 실패 이벤트가 아니다.
+- preview 실패와 missing listing identity는 listing failure fact로 전달된다.
+- abort cleanup은 checking item을 정리하고 failure fact를 만들지 않는다.
+
+### `save-workflow.test.ts`
+
+- directory 저장 성공 시 saving -> saved 전환과 save completed fact가 발생한다.
+- directory 저장 일부 실패 시 실패 item만 listing failure fact를 만든다.
+- ZIP fallback 성공 시 대상 전체가 saved가 된다.
+- ZIP fallback 실패 시 대상 전체가 failed가 되고 save failed fact가 발생한다.
+- save 취소는 실패 이벤트로 기록하지 않는다.
+
+### `workflow-analytics.test.ts`
+
+- workflow fact가 기존 Umami wrapper 입력으로 정확히 변환된다.
+- 성공 매물 payload에는 URL, 차량번호, 차명이 포함되지 않는다.
+- 저장 실패한 parsed listing만 차량번호, 차명, 이미지 수를 포함한다.
+- removed listing id는 batch 매핑과 save failure 상태에서 제거된다.
+- fallback save batch는 기존 batch 매핑이 없는 ready item에도 안전하게 생성된다.
+
+### `truck-harvester-app.test.tsx`
+
+- UI 통합 테스트는 붙여넣기와 저장 버튼이 workflow command를 통해 동작하는지
+  확인한다.
+- analytics 세부 payload 검증은 application 계층 테스트로 이동한다.
+- 온보딩 중 background controls 비활성화, 폴더 영구 보관 금지, saved listing
+  표시 같은 route-level 보장은 유지한다.
+
+## 문서 갱신
+
+- `docs/architecture.md`: `src/v2/application` 계층과 tracking adapter 경계를
+  추가한다.
+- `src/v2/AGENTS.md`: layer map에 application 계층을 추가한다.
+- `src/v2/application/AGENTS.md`: application 계층의 import 규칙과 testing
+  규칙을 둔다.
+- 필요하면 `docs/runbooks/`에 workflow 변경 시 만질 위치를 추가한다.
+
+## 수용 기준
+
+- `truck-harvester-app.tsx`는 analytics wrapper를 직접 import하지 않는다.
+- route component는 batch id, analytics batch group, failure payload를 직접
+  만들지 않는다.
+- preview/save use case는 React component 없이 단위 테스트된다.
+- workflow analytics는 prepared listing store를 직접 mutate하지 않는다.
+- 기존 analytics 수집 정책이 유지된다.
+- `bun run typecheck`, `bun run lint`, `bun run format:check`,
+  `bun run test -- --run`이 통과한다.
+
+## 리스크와 완화
+
+- 파일 이동으로 테스트 mock 경계가 흔들릴 수 있다. 먼저 application 테스트를
+  추가한 뒤 route 통합 테스트를 얇게 줄인다.
+- tracking adapter가 비대해질 수 있다. Umami payload 변환과 batch 매핑 외의
+  업무 규칙은 preview/save use case에 남긴다.
+- 새 계층이 또 다른 애매한 shared 폴더가 될 수 있다. application은 root app
+  workflow만 소유하고, generic helper는 `shared`로 보내지 않는다.

--- a/src/app/__tests__/page.test.tsx
+++ b/src/app/__tests__/page.test.tsx
@@ -20,12 +20,16 @@ const { JSDOM } = require('jsdom') as {
 }
 
 vi.mock('@/v2/features/listing-preparation', async () => {
+  const parser = await vi.importActual<
+    typeof import('@/v2/features/listing-preparation/model/url-input-parser')
+  >('@/v2/features/listing-preparation/model/url-input-parser')
   const store = await vi.importActual<
     typeof import('@/v2/features/listing-preparation/model/prepared-listing-store')
   >('@/v2/features/listing-preparation/model/prepared-listing-store')
 
   return {
     createPreparedListingStore: store.createPreparedListingStore,
+    parseUrlInputText: parser.parseUrlInputText,
     prepareListingUrls: listingPreparationMocks.prepareListingUrls,
     selectCheckingPreparedListings: store.selectCheckingPreparedListings,
     selectReadyPreparedListings: store.selectReadyPreparedListings,

--- a/src/app/__tests__/truck-harvester-app.test.tsx
+++ b/src/app/__tests__/truck-harvester-app.test.tsx
@@ -7,7 +7,6 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { type TruckListing } from '@/v2/entities/truck'
 import { type WritableDirectoryHandle } from '@/v2/features/file-management'
-import { type PrepareListingUrlsInput } from '@/v2/features/listing-preparation'
 import { onboardingStorageKey } from '@/v2/shared/model'
 
 const analyticsMocks = vi.hoisted(() => ({
@@ -34,6 +33,9 @@ vi.mock('@/v2/features/listing-preparation', async () => {
   const store = await vi.importActual<
     typeof import('@/v2/features/listing-preparation/model/prepared-listing-store')
   >('@/v2/features/listing-preparation/model/prepared-listing-store')
+  const parser = await vi.importActual<
+    typeof import('@/v2/features/listing-preparation/model/url-input-parser')
+  >('@/v2/features/listing-preparation/model/url-input-parser')
 
   listingPreparationMocks.prepareListingUrls.mockImplementation(
     prepare.prepareListingUrls
@@ -41,6 +43,7 @@ vi.mock('@/v2/features/listing-preparation', async () => {
 
   return {
     createPreparedListingStore: store.createPreparedListingStore,
+    parseUrlInputText: parser.parseUrlInputText,
     prepareListingUrls: listingPreparationMocks.prepareListingUrls,
     selectCheckingPreparedListings: store.selectCheckingPreparedListings,
     selectReadyPreparedListings: store.selectReadyPreparedListings,
@@ -250,12 +253,6 @@ afterEach(() => {
   })
 })
 
-const expectNoVehicleIdentity = (payload: object | undefined) => {
-  expect(payload).toBeDefined()
-  expect(payload).not.toHaveProperty('vehicleNumber')
-  expect(payload).not.toHaveProperty('vehicleName')
-}
-
 const createTruckListing = (
   url: string,
   overrides: Partial<TruckListing> = {}
@@ -420,11 +417,6 @@ const disableFileSystemAccess = () => {
     Reflect.deleteProperty(window, 'showDirectoryPicker')
   }
 }
-
-const getSaveListingFailures = () =>
-  analyticsMocks.trackListingFailed.mock.calls
-    .map(([payload]) => payload)
-    .filter((payload) => payload.failureStage === 'save')
 
 describe('TruckHarvesterApp persistence', () => {
   it('disables the four background controls while onboarding is open', async () => {
@@ -689,25 +681,9 @@ describe('TruckHarvesterApp persistence', () => {
     expect(statusRegion?.textContent).toContain('현대 메가트럭')
     expect(statusRegion?.textContent).toContain('저장 완료')
     expect(inputRegion?.textContent).not.toContain('현대 메가트럭')
-    expect(analyticsMocks.trackSaveStarted).toHaveBeenCalledWith(
-      expect.objectContaining({
-        batchId: 'batch-1',
-        saveMethod: 'directory',
-        readyCount: 1,
-      })
-    )
-    expect(analyticsMocks.trackSaveCompleted).toHaveBeenCalledWith(
-      expect.objectContaining({
-        batchId: 'batch-1',
-        saveMethod: 'directory',
-        savedCount: 1,
-        saveFailedCount: 0,
-      })
-    )
-    expect(analyticsMocks.trackSaveFailed).not.toHaveBeenCalled()
   })
 
-  it('tracks batch and preview completion without success listing identifiers', async () => {
+  it('renders a parsed listing in the input and status regions after paste', async () => {
     const truckUrl =
       'https://www.truck-no1.co.kr/model/DetailView.asp?ShopNo=1&MemberNo=2&OnCarNo=3'
 
@@ -791,32 +767,20 @@ describe('TruckHarvesterApp persistence', () => {
       })
     }
 
-    expect(analyticsMocks.trackBatchStarted).toHaveBeenCalledWith(
-      expect.objectContaining({
-        batchId: 'batch-1',
-        urlCount: 1,
-        uniqueUrlCount: 1,
-        readyCount: 0,
-        invalidCount: 0,
-        previewFailedCount: 0,
-        savedCount: 0,
-        saveFailedCount: 0,
-      })
+    const inputRegion = container.querySelector(
+      'section[aria-labelledby="listing-chip-input-title"]'
     )
-    expect(analyticsMocks.trackPreviewCompleted).toHaveBeenCalledWith(
-      expect.objectContaining({
-        batchId: 'batch-1',
-        urlCount: 1,
-        uniqueUrlCount: 1,
-        readyCount: 1,
-        invalidCount: 0,
-        previewFailedCount: 0,
-      })
+    const statusRegion = container.querySelector(
+      'section[aria-labelledby="prepared-listing-status-title"]'
     )
-    expect(analyticsMocks.trackListingFailed).not.toHaveBeenCalled()
+
+    expect(inputRegion?.textContent).toContain('현대 메가트럭')
+    expect(inputRegion?.textContent).toContain('확인 완료')
+    expect(statusRegion?.textContent).toContain('현대 메가트럭')
+    expect(statusRegion?.textContent).toContain('저장 준비 완료')
   })
 
-  it('tracks unsupported non-empty pasted input once without starting preview', async () => {
+  it('shows guidance for unsupported non-empty pasted input without starting preview', async () => {
     const unsupportedInput =
       '  DetailView.asp?ShopNo=30195108&MemberNo=1000294965&OnCarNo=2026300055501\nabc...  '
 
@@ -826,37 +790,26 @@ describe('TruckHarvesterApp persistence', () => {
     await pasteListingText(unsupportedInput)
     await flushAsyncUi(2)
 
-    expect(analyticsMocks.createAnalyticsBatchId).toHaveBeenCalledTimes(1)
-    expect(analyticsMocks.trackUnsupportedInputFailure).toHaveBeenCalledTimes(1)
-    expect(analyticsMocks.trackUnsupportedInputFailure).toHaveBeenCalledWith({
-      batchId: 'batch-1',
-      rawInput: unsupportedInput,
-      elapsedMs: expect.any(Number),
-    })
-    expect(listingPreparationMocks.prepareListingUrls).not.toHaveBeenCalled()
-    expect(analyticsMocks.trackBatchStarted).not.toHaveBeenCalled()
-    expect(analyticsMocks.trackPreviewCompleted).not.toHaveBeenCalled()
     expect(container?.textContent).toContain(
       '매물 주소를 찾지 못했어요. 복사한 내용을 다시 확인해 주세요.'
     )
+    expect(listingPreparationMocks.prepareListingUrls).not.toHaveBeenCalled()
   })
 
-  it('does not track empty pasted input as an unsupported input failure', async () => {
+  it('shows guidance for empty pasted input without starting preview', async () => {
     installDom({} as WritableDirectoryHandle)
     await renderTruckHarvesterApp()
 
     await pasteListingText(' \n\t ')
     await flushAsyncUi(2)
 
-    expect(analyticsMocks.createAnalyticsBatchId).not.toHaveBeenCalled()
-    expect(analyticsMocks.trackUnsupportedInputFailure).not.toHaveBeenCalled()
     expect(listingPreparationMocks.prepareListingUrls).not.toHaveBeenCalled()
     expect(container?.textContent).toContain(
       '매물 주소를 찾지 못했어요. 복사한 내용을 다시 확인해 주세요.'
     )
   })
 
-  it('does not track surrounding prose as unsupported input when a valid listing url is present', async () => {
+  it('extracts a valid listing url from surrounding prose', async () => {
     const truckUrl =
       'https://www.truck-no1.co.kr/model/DetailView.asp?ShopNo=1&MemberNo=2&OnCarNo=21'
 
@@ -867,18 +820,11 @@ describe('TruckHarvesterApp persistence', () => {
     await pasteListingText(`확인 부탁드립니다\n${truckUrl}\nabc...`)
     await flushAsyncUi(4)
 
-    expect(analyticsMocks.trackUnsupportedInputFailure).not.toHaveBeenCalled()
     expect(listingPreparationMocks.prepareListingUrls).toHaveBeenCalledTimes(1)
-    expect(analyticsMocks.trackBatchStarted).toHaveBeenCalledWith(
-      expect.objectContaining({
-        batchId: 'batch-1',
-        urlCount: 1,
-        uniqueUrlCount: 1,
-      })
-    )
+    expect(container?.textContent).toContain('현대 메가트럭')
   })
 
-  it('tracks preview failures with listing url but without vehicle identifiers', async () => {
+  it('renders preview failures as recoverable listing guidance', async () => {
     const truckUrl =
       'https://www.truck-no1.co.kr/model/DetailView.asp?ShopNo=1&MemberNo=2&OnCarNo=5'
 
@@ -936,39 +882,28 @@ describe('TruckHarvesterApp persistence', () => {
       })
     }
 
-    expect(analyticsMocks.trackPreviewCompleted).toHaveBeenCalledWith(
-      expect.objectContaining({
-        batchId: 'batch-1',
-        previewFailedCount: 1,
-      })
+    const inputRegion = container.querySelector(
+      'section[aria-labelledby="listing-chip-input-title"]'
     )
-    expect(analyticsMocks.trackListingFailed).toHaveBeenCalledWith(
-      expect.objectContaining({
-        batchId: 'batch-1',
-        failureStage: 'preview',
-        listingUrl: truckUrl,
-      })
+    const statusRegion = container.querySelector(
+      'section[aria-labelledby="prepared-listing-status-title"]'
     )
 
-    const previewFailurePayload =
-      analyticsMocks.trackListingFailed.mock.calls.find(
-        ([payload]) =>
-          payload.failureStage === 'preview' && payload.listingUrl === truckUrl
-      )?.[0]
-
-    expectNoVehicleIdentity(previewFailurePayload)
+    expect(inputRegion?.textContent).toContain('확인 필요')
+    expect(inputRegion?.textContent).toContain(
+      '확인하지 못한 매물은 지우고 다시 붙여넣어 주세요.'
+    )
+    expect(statusRegion?.textContent).toContain(
+      '매물 이름을 확인하지 못했어요. 잠시 후 다시 붙여넣어 주세요.'
+    )
   })
 
-  it('tracks superseded preview runs without overwriting latest duplicate helper text', async () => {
+  it('keeps latest duplicate helper text when an older preview resolves later', async () => {
     const olderTruckUrl =
       'https://www.truck-no1.co.kr/model/DetailView.asp?ShopNo=1&MemberNo=2&OnCarNo=7'
     const newerTruckUrl =
       'https://www.truck-no1.co.kr/model/DetailView.asp?ShopNo=1&MemberNo=2&OnCarNo=8'
     const olderPreview = createDeferred<Response>()
-
-    analyticsMocks.createAnalyticsBatchId
-      .mockReturnValueOnce('batch-old')
-      .mockReturnValueOnce('batch-latest')
 
     installDom({} as WritableDirectoryHandle)
     markOnboardingComplete()
@@ -1084,216 +1019,9 @@ describe('TruckHarvesterApp persistence', () => {
     }
 
     expect(container.textContent).toContain('이미 넣은 매물이에요.')
-    expect(analyticsMocks.trackBatchStarted).toHaveBeenCalledWith(
-      expect.objectContaining({
-        batchId: 'batch-old',
-        urlCount: 1,
-        uniqueUrlCount: 1,
-      })
-    )
-    expect(analyticsMocks.trackBatchStarted).toHaveBeenCalledWith(
-      expect.objectContaining({
-        batchId: 'batch-latest',
-        urlCount: 2,
-        uniqueUrlCount: 2,
-      })
-    )
-    expect(analyticsMocks.trackPreviewCompleted).toHaveBeenCalledWith(
-      expect.objectContaining({
-        batchId: 'batch-latest',
-        urlCount: 2,
-        uniqueUrlCount: 1,
-        readyCount: 1,
-        previewFailedCount: 0,
-      })
-    )
-    expect(analyticsMocks.trackPreviewCompleted).toHaveBeenCalledWith(
-      expect.objectContaining({
-        batchId: 'batch-old',
-        urlCount: 1,
-        uniqueUrlCount: 1,
-        readyCount: 0,
-        previewFailedCount: 1,
-      })
-    )
-
-    const olderFailurePayload =
-      analyticsMocks.trackListingFailed.mock.calls.find(
-        ([payload]) =>
-          payload.failureStage === 'preview' &&
-          payload.listingUrl === olderTruckUrl
-      )?.[0]
-
-    expect(olderFailurePayload).toEqual(
-      expect.objectContaining({
-        batchId: 'batch-old',
-        failureStage: 'preview',
-        listingUrl: olderTruckUrl,
-      })
-    )
-    expectNoVehicleIdentity(olderFailurePayload)
   })
 
-  it('does not attach an old same-url preview run to a newer pasted item', async () => {
-    const truckUrl =
-      'https://www.truck-no1.co.kr/model/DetailView.asp?ShopNo=1&MemberNo=2&OnCarNo=9'
-    const oldPreview = createDeferred<Response>()
-
-    analyticsMocks.createAnalyticsBatchId
-      .mockReturnValueOnce('batch-old')
-      .mockReturnValueOnce('batch-new')
-
-    installDom({} as WritableDirectoryHandle)
-    markOnboardingComplete()
-    Object.defineProperty(globalThis, 'fetch', {
-      configurable: true,
-      value: vi
-        .fn()
-        .mockReturnValueOnce(oldPreview.promise)
-        .mockResolvedValueOnce(
-          Response.json({
-            success: true,
-            data: {
-              url: truckUrl,
-              vname: '현대 메가트럭',
-              vehicleName: '현대 메가트럭',
-              vnumber: '서울12가3456',
-              price: {
-                raw: 3200,
-                rawWon: 32000000,
-                label: '3,200만원',
-                compactLabel: '3,200만원',
-              },
-              year: '2020',
-              mileage: '120,000km',
-              options: '윙바디',
-              images: [],
-            },
-          })
-        ),
-    })
-
-    const { TruckHarvesterApp } = await import('../truck-harvester-app')
-
-    container = document.createElement('div')
-    document.body.append(container)
-    root = createRoot(container)
-
-    await act(async () => {
-      root?.render(<TruckHarvesterApp />)
-      await new Promise((resolve) => window.setTimeout(resolve, 0))
-    })
-
-    const textarea = container.querySelector(
-      'textarea[placeholder="복사한 내용을 여기에 붙여넣으세요"]'
-    )
-
-    if (!(textarea instanceof HTMLTextAreaElement)) {
-      throw new Error('매물 주소 입력란을 찾지 못했습니다.')
-    }
-
-    const oldPasteEvent = new Event('paste', {
-      bubbles: true,
-      cancelable: true,
-    })
-    Object.defineProperty(oldPasteEvent, 'clipboardData', {
-      value: { getData: () => truckUrl },
-    })
-
-    await act(async () => {
-      textarea.dispatchEvent(oldPasteEvent)
-    })
-
-    for (let index = 0; index < 2; index += 1) {
-      await act(async () => {
-        await Promise.resolve()
-        await new Promise((resolve) => window.setTimeout(resolve, 0))
-      })
-    }
-
-    const removeButton = Array.from(container.querySelectorAll('button')).find(
-      (button) => button.getAttribute('aria-label')?.startsWith('매물 지우기:')
-    )
-
-    expect(removeButton).toBeInstanceOf(HTMLButtonElement)
-
-    await act(async () => {
-      removeButton?.dispatchEvent(
-        new dom!.window.MouseEvent('click', { bubbles: true })
-      )
-    })
-
-    const newPasteEvent = new Event('paste', {
-      bubbles: true,
-      cancelable: true,
-    })
-    Object.defineProperty(newPasteEvent, 'clipboardData', {
-      value: { getData: () => truckUrl },
-    })
-
-    await act(async () => {
-      textarea.dispatchEvent(newPasteEvent)
-    })
-
-    for (let index = 0; index < 4; index += 1) {
-      await act(async () => {
-        await Promise.resolve()
-        await new Promise((resolve) => window.setTimeout(resolve, 0))
-      })
-    }
-
-    expect(analyticsMocks.trackPreviewCompleted).toHaveBeenCalledWith(
-      expect.objectContaining({
-        batchId: 'batch-new',
-        uniqueUrlCount: 1,
-        readyCount: 1,
-        previewFailedCount: 0,
-      })
-    )
-
-    oldPreview.resolve(
-      Response.json(
-        {
-          success: false,
-          reason: 'site-timeout',
-          message: '사이트 응답이 늦습니다.',
-        },
-        { status: 504 }
-      )
-    )
-
-    for (let index = 0; index < 4; index += 1) {
-      await act(async () => {
-        await Promise.resolve()
-        await new Promise((resolve) => window.setTimeout(resolve, 0))
-      })
-    }
-
-    expect(analyticsMocks.trackPreviewCompleted).toHaveBeenCalledWith(
-      expect.objectContaining({
-        batchId: 'batch-old',
-        uniqueUrlCount: 1,
-        readyCount: 0,
-        previewFailedCount: 1,
-      })
-    )
-    expect(analyticsMocks.trackPreviewCompleted).not.toHaveBeenCalledWith(
-      expect.objectContaining({
-        batchId: 'batch-old',
-        uniqueUrlCount: 1,
-        readyCount: 1,
-      })
-    )
-    expect(analyticsMocks.trackListingFailed).toHaveBeenCalledWith(
-      expect.objectContaining({
-        batchId: 'batch-old',
-        failureStage: 'preview',
-        listingUrl: truckUrl,
-      })
-    )
-  })
-
-  it('tracks invalid listing identity as an invalid_url failure', async () => {
+  it('renders invalid listing identity as address-check guidance', async () => {
     const truckUrl =
       'https://www.truck-no1.co.kr/model/DetailView.asp?ShopNo=1&MemberNo=2&OnCarNo=6'
 
@@ -1362,87 +1090,20 @@ describe('TruckHarvesterApp persistence', () => {
       })
     }
 
-    expect(analyticsMocks.trackListingFailed).toHaveBeenCalledWith(
-      expect.objectContaining({
-        batchId: 'batch-1',
-        failureStage: 'invalid_url',
-        listingUrl: truckUrl,
-      })
+    const inputRegion = container.querySelector(
+      'section[aria-labelledby="listing-chip-input-title"]'
+    )
+    const statusRegion = container.querySelector(
+      'section[aria-labelledby="prepared-listing-status-title"]'
     )
 
-    const invalidFailurePayload =
-      analyticsMocks.trackListingFailed.mock.calls.find(
-        ([payload]) =>
-          payload.failureStage === 'invalid_url' &&
-          payload.listingUrl === truckUrl
-      )?.[0]
-
-    expectNoVehicleIdentity(invalidFailurePayload)
+    expect(inputRegion?.textContent).toContain('확인 필요')
+    expect(statusRegion?.textContent).toContain(
+      '매물 정보를 찾지 못했어요. 주소를 다시 확인해 주세요.'
+    )
   })
 
-  it('tracks save summaries per paste batch when saving ready listings together', async () => {
-    const firstUrl =
-      'https://www.truck-no1.co.kr/model/DetailView.asp?ShopNo=1&MemberNo=2&OnCarNo=11'
-    const secondUrl =
-      'https://www.truck-no1.co.kr/model/DetailView.asp?ShopNo=1&MemberNo=2&OnCarNo=12'
-    const firstListing = createTruckListing(firstUrl, {
-      vname: '현대 메가트럭',
-      vnumber: '서울11가1111',
-    })
-    const secondListing = createTruckListing(secondUrl, {
-      vname: '기아 봉고',
-      vnumber: '부산22나2222',
-    })
-    const restoredDirectory = createWritableDirectory()
-
-    analyticsMocks.createAnalyticsBatchId
-      .mockReturnValueOnce('batch-first')
-      .mockReturnValueOnce('batch-second')
-
-    installDom(restoredDirectory)
-    mockParseResponses([firstListing, secondListing])
-    await renderTruckHarvesterApp()
-    await selectSaveDirectory(restoredDirectory)
-
-    await pasteListingText(firstUrl)
-    await flushAsyncUi()
-    await pasteListingText(secondUrl)
-    await flushAsyncUi()
-    await startSavingReadyListings()
-    await flushAsyncUi(6)
-
-    expect(analyticsMocks.trackSaveStarted).toHaveBeenCalledWith(
-      expect.objectContaining({
-        batchId: 'batch-first',
-        saveMethod: 'directory',
-        readyCount: 1,
-      })
-    )
-    expect(analyticsMocks.trackSaveStarted).toHaveBeenCalledWith(
-      expect.objectContaining({
-        batchId: 'batch-second',
-        saveMethod: 'directory',
-        readyCount: 1,
-      })
-    )
-    expect(analyticsMocks.trackSaveCompleted).toHaveBeenCalledWith(
-      expect.objectContaining({
-        batchId: 'batch-first',
-        savedCount: 1,
-        saveFailedCount: 0,
-      })
-    )
-    expect(analyticsMocks.trackSaveCompleted).toHaveBeenCalledWith(
-      expect.objectContaining({
-        batchId: 'batch-second',
-        savedCount: 1,
-        saveFailedCount: 0,
-      })
-    )
-    expect(analyticsMocks.trackSaveFailed).not.toHaveBeenCalled()
-  })
-
-  it('tracks partial directory save failures without failing saved listings', async () => {
+  it('keeps partial directory save failures separate from saved listings', async () => {
     const savedUrl =
       'https://www.truck-no1.co.kr/model/DetailView.asp?ShopNo=1&MemberNo=2&OnCarNo=13'
     const failedUrl =
@@ -1460,8 +1121,6 @@ describe('TruckHarvesterApp persistence', () => {
       new Set([failedListing.vnumber])
     )
 
-    analyticsMocks.createAnalyticsBatchId.mockReturnValueOnce('batch-partial')
-
     installDom(restoredDirectory)
     mockParseResponses([savedListing, failedListing])
     await renderTruckHarvesterApp()
@@ -1472,35 +1131,23 @@ describe('TruckHarvesterApp persistence', () => {
     await startSavingReadyListings()
     await flushAsyncUi(6)
 
-    expect(analyticsMocks.trackSaveFailed).toHaveBeenCalledWith(
-      expect.objectContaining({
-        batchId: 'batch-partial',
-        saveMethod: 'directory',
-        readyCount: 2,
-        savedCount: 1,
-        saveFailedCount: 1,
-      })
+    const statusRegion = container?.querySelector(
+      'section[aria-labelledby="prepared-listing-status-title"]'
     )
-    expect(analyticsMocks.trackSaveCompleted).not.toHaveBeenCalledWith(
-      expect.objectContaining({
-        batchId: 'batch-partial',
-      })
+    const inputRegion = container?.querySelector(
+      'section[aria-labelledby="listing-chip-input-title"]'
     )
 
-    const saveFailures = getSaveListingFailures()
-
-    expect(saveFailures).toHaveLength(1)
-    expect(saveFailures[0]).toEqual(
-      expect.objectContaining({
-        batchId: 'batch-partial',
-        listingUrl: failedUrl,
-        vehicleNumber: '인천44라4444',
-        vehicleName: '대우 프리마',
-      })
+    expect(statusRegion?.textContent).toContain('현대 메가트럭')
+    expect(statusRegion?.textContent).toContain('저장 완료')
+    expect(statusRegion?.textContent).toContain(
+      '저장하지 못했어요. 저장 폴더와 인터넷 연결을 확인한 뒤 다시 시도해 주세요.'
     )
+    expect(inputRegion?.textContent).not.toContain('현대 메가트럭')
+    expect(inputRegion?.textContent).toContain('확인 필요')
   })
 
-  it('tracks zip fallback failures as zip save failures', async () => {
+  it('shows a recoverable failure when zip fallback cannot be created', async () => {
     const truckUrl =
       'https://www.truck-no1.co.kr/model/DetailView.asp?ShopNo=1&MemberNo=2&OnCarNo=15'
     const listing = createTruckListing(truckUrl, {
@@ -1508,8 +1155,6 @@ describe('TruckHarvesterApp persistence', () => {
       vehicleName: '현대 엑시언트',
       vnumber: '대구55마5555',
     })
-
-    analyticsMocks.createAnalyticsBatchId.mockReturnValueOnce('batch-zip')
 
     installDom({} as WritableDirectoryHandle)
     disableFileSystemAccess()
@@ -1527,227 +1172,12 @@ describe('TruckHarvesterApp persistence', () => {
     await startSavingReadyListings()
     await flushAsyncUi(6)
 
-    expect(analyticsMocks.trackSaveStarted).toHaveBeenCalledWith(
-      expect.objectContaining({
-        batchId: 'batch-zip',
-        saveMethod: 'zip',
-      })
-    )
-    expect(analyticsMocks.trackSaveFailed).toHaveBeenCalledWith(
-      expect.objectContaining({
-        batchId: 'batch-zip',
-        saveMethod: 'zip',
-        saveFailedCount: 1,
-      })
-    )
-    expect(getSaveListingFailures()).toEqual([
-      expect.objectContaining({
-        batchId: 'batch-zip',
-        listingUrl: truckUrl,
-        vehicleNumber: '대구55마5555',
-        vehicleName: '현대 엑시언트',
-      }),
-    ])
-  })
-
-  it('uses a fallback save batch when a ready listing has no preview mapping', async () => {
-    const truckUrl =
-      'https://www.truck-no1.co.kr/model/DetailView.asp?ShopNo=1&MemberNo=2&OnCarNo=16'
-    const listing = createTruckListing(truckUrl, {
-      vname: '타타대우 노부스',
-      vehicleName: '타타대우 노부스',
-      vnumber: '광주66바6666',
-    })
-    const restoredDirectory = createWritableDirectory()
-
-    analyticsMocks.createAnalyticsBatchId
-      .mockReturnValueOnce('batch-preview')
-      .mockReturnValueOnce('batch-fallback')
-    listingPreparationMocks.prepareListingUrls.mockImplementationOnce(
-      async ({ urls, store }: PrepareListingUrlsInput) => {
-        const result = store.getState().addUrls([...urls])
-        const item = store
-          .getState()
-          .items.find(
-            (entry) => entry.url === truckUrl && entry.status === 'checking'
-          )
-
-        if (!item) {
-          throw new Error('테스트 매물을 준비하지 못했습니다.')
-        }
-
-        store.getState().markReadyById(item.id, listing)
-
-        return {
-          ...result,
-          addedItems: [],
-          settledItems: [
-            {
-              id: item.id,
-              url: truckUrl,
-              status: 'ready' as const,
-            },
-          ],
-        }
-      }
+    const statusRegion = container?.querySelector(
+      'section[aria-labelledby="prepared-listing-status-title"]'
     )
 
-    installDom(restoredDirectory)
-    await renderTruckHarvesterApp()
-    await selectSaveDirectory(restoredDirectory)
-
-    await pasteListingText(truckUrl)
-    await flushAsyncUi()
-    await startSavingReadyListings()
-    await flushAsyncUi(6)
-
-    expect(analyticsMocks.trackSaveStarted).not.toHaveBeenCalledWith(
-      expect.objectContaining({
-        batchId: 'batch-preview',
-      })
-    )
-    expect(analyticsMocks.trackSaveStarted).toHaveBeenCalledWith(
-      expect.objectContaining({
-        batchId: 'batch-fallback',
-        saveMethod: 'directory',
-        readyCount: 1,
-      })
-    )
-    expect(analyticsMocks.trackSaveCompleted).toHaveBeenCalledWith(
-      expect.objectContaining({
-        batchId: 'batch-fallback',
-        saveMethod: 'directory',
-        savedCount: 1,
-        saveFailedCount: 0,
-      })
-    )
-  })
-
-  it('tracks save failures with vehicle identifiers for parsed listings', async () => {
-    const truckUrl =
-      'https://www.truck-no1.co.kr/model/DetailView.asp?ShopNo=1&MemberNo=2&OnCarNo=7'
-    const requestPermission = vi.fn().mockResolvedValue('granted')
-    const restoredDirectory: WritableDirectoryHandle = {
-      getDirectoryHandle: vi.fn().mockRejectedValue(new Error('disk full')),
-      getFileHandle: async () => {
-        throw new Error('테스트에서는 파일에 쓰지 않습니다.')
-      },
-      name: 'truck-test',
-      requestPermission,
-    }
-
-    installDom(restoredDirectory)
-    markOnboardingComplete()
-    Object.defineProperty(globalThis, 'fetch', {
-      configurable: true,
-      value: vi.fn().mockResolvedValue(
-        Response.json({
-          success: true,
-          data: {
-            url: truckUrl,
-            vname: '차명 정보 없음',
-            vehicleName: '현대 메가트럭',
-            vnumber: '서울12가3456',
-            price: {
-              raw: 3200,
-              rawWon: 32000000,
-              label: '3,200만원',
-              compactLabel: '3,200만원',
-            },
-            year: '2020',
-            mileage: '120,000km',
-            options: '윙바디',
-            images: [],
-          },
-        })
-      ),
-    })
-
-    const { TruckHarvesterApp } = await import('../truck-harvester-app')
-
-    container = document.createElement('div')
-    document.body.append(container)
-    root = createRoot(container)
-
-    await act(async () => {
-      root?.render(<TruckHarvesterApp />)
-      await new Promise((resolve) => window.setTimeout(resolve, 0))
-    })
-
-    Object.defineProperty(window, 'showDirectoryPicker', {
-      configurable: true,
-      value: vi.fn().mockResolvedValue(restoredDirectory),
-    })
-
-    const folderButton = Array.from(container.querySelectorAll('button')).find(
-      (button) => button.textContent === '저장 폴더 고르기'
-    )
-    await act(async () => {
-      folderButton?.dispatchEvent(
-        new dom!.window.MouseEvent('click', { bubbles: true })
-      )
-    })
-
-    const textarea = container.querySelector(
-      'textarea[placeholder="복사한 내용을 여기에 붙여넣으세요"]'
-    )
-
-    if (!(textarea instanceof HTMLTextAreaElement)) {
-      throw new Error('매물 주소 입력란을 찾지 못했습니다.')
-    }
-
-    const pasteEvent = new Event('paste', {
-      bubbles: true,
-      cancelable: true,
-    })
-    Object.defineProperty(pasteEvent, 'clipboardData', {
-      value: { getData: () => truckUrl },
-    })
-
-    await act(async () => {
-      textarea.dispatchEvent(pasteEvent)
-    })
-
-    for (let index = 0; index < 4; index += 1) {
-      await act(async () => {
-        await Promise.resolve()
-        await new Promise((resolve) => window.setTimeout(resolve, 0))
-      })
-    }
-
-    const startButton = Array.from(container.querySelectorAll('button')).find(
-      (button) => button.textContent === '확인된 1대 저장 시작'
-    )
-
-    await act(async () => {
-      startButton?.dispatchEvent(
-        new dom!.window.MouseEvent('click', { bubbles: true })
-      )
-    })
-
-    for (let index = 0; index < 6; index += 1) {
-      await act(async () => {
-        await Promise.resolve()
-        await new Promise((resolve) => window.setTimeout(resolve, 0))
-      })
-    }
-
-    expect(analyticsMocks.trackSaveFailed).toHaveBeenCalledWith(
-      expect.objectContaining({
-        batchId: 'batch-1',
-        saveMethod: 'directory',
-        saveFailedCount: 1,
-      })
-    )
-    expect(analyticsMocks.trackListingFailed).toHaveBeenCalledWith(
-      expect.objectContaining({
-        batchId: 'batch-1',
-        failureStage: 'save',
-        listingUrl: truckUrl,
-        vehicleNumber: '서울12가3456',
-        vehicleName: '현대 메가트럭',
-        imageCount: 0,
-      })
+    expect(statusRegion?.textContent).toContain(
+      '저장하지 못했어요. 저장 폴더와 인터넷 연결을 확인한 뒤 다시 시도해 주세요.'
     )
   })
 })

--- a/src/app/truck-harvester-app.tsx
+++ b/src/app/truck-harvester-app.tsx
@@ -1,695 +1,18 @@
 'use client'
 
-import { useEffect, useLayoutEffect, useRef, useState } from 'react'
-
-import { useStore } from 'zustand'
-
-import {
-  CompletionNotificationToggle,
-  isCompletionNotificationAvailable,
-  notifyCompletion,
-  requestCompletionNotificationPermission,
-} from '@/v2/features/completion-notification'
-import {
-  downloadTruckZip,
-  isFileSystemAccessAvailable,
-  pickWritableDirectory,
-  requestWritableDirectoryPermission,
-  saveTruckToDirectory,
-  type WritableDirectoryHandle,
-} from '@/v2/features/file-management'
-import {
-  createPreparedListingStore,
-  prepareListingUrls,
-  selectCheckingPreparedListings,
-  selectReadyPreparedListings,
-  type PreparedListing,
-  type ReadyPreparedListing,
-} from '@/v2/features/listing-preparation'
+import { useTruckHarvesterWorkflow } from '@/v2/application'
+import { CompletionNotificationToggle } from '@/v2/features/completion-notification'
 import {
   HelpMenuButton,
   TourOverlay,
   tourSteps,
 } from '@/v2/features/onboarding'
-import {
-  createAnalyticsBatchId,
-  trackBatchStarted,
-  trackListingFailed,
-  trackPreviewCompleted,
-  trackSaveCompleted,
-  trackSaveFailed,
-  trackSaveStarted,
-  trackUnsupportedInputFailure,
-  type SaveMethod,
-} from '@/v2/shared/lib/analytics'
-import { createOnboardingStore } from '@/v2/shared/model'
 import { DirectorySelector } from '@/v2/widgets/directory-selector'
 import { PreparedListingStatusPanel } from '@/v2/widgets/processing-status'
-import { ListingChipInput, parseUrlInputText } from '@/v2/widgets/url-input'
-
-const saveFailureMessage =
-  '저장하지 못했어요. 저장 폴더와 인터넷 연결을 확인한 뒤 다시 시도해 주세요.'
-const saveFolderPickerId = 'truck-harvester-v2-save-folder'
-const missingListingIdentityPlaceholder = '차명 정보 없음'
-const useBrowserLayoutEffect =
-  typeof window === 'undefined' ? useEffect : useLayoutEffect
-
-type DirectoryPermissionState = 'denied' | 'ready'
-type DirectoryPickerStartIn = WritableDirectoryHandle | 'downloads'
-
-interface AnalyticsBatchState {
-  id: string
-  startedAt: number
-  urlCount: number
-}
-
-interface AnalyticsSaveBatchGroup {
-  batch: AnalyticsBatchState
-  items: ReadyPreparedListing[]
-}
-
-type AnalyticsPreviewItem =
-  | { id: string; url: string; status: 'ready' }
-  | { id: string; url: string; status: 'failed' | 'invalid'; message: string }
-
-interface BatchAnalyticsSaveOptions {
-  savedCount?: number
-  saveFailedCount?: number
-  saveMethod?: SaveMethod
-}
-
-const pickSaveDirectory = pickWritableDirectory as (options: {
-  id: string
-  startIn: DirectoryPickerStartIn
-}) => Promise<WritableDirectoryHandle | undefined>
-
-const requestNextFrame = (callback: () => void) => {
-  if (typeof window.requestAnimationFrame === 'function') {
-    return window.requestAnimationFrame(callback)
-  }
-
-  return window.setTimeout(callback, 16)
-}
-
-const cancelNextFrame = (handle: number) => {
-  if (typeof window.cancelAnimationFrame === 'function') {
-    window.cancelAnimationFrame(handle)
-    return
-  }
-
-  window.clearTimeout(handle)
-}
-
-const getAnalyticsNow = () =>
-  typeof performance !== 'undefined' ? performance.now() : Date.now()
-
-const getAnalyticsDuration = (startedAt: number) =>
-  Math.max(0, Math.round(getAnalyticsNow() - startedAt))
-
-const isNotificationEnabled = (
-  permission: NotificationPermission | 'unsupported'
-) => permission === 'granted'
-
-const isUsableListingIdentity = (value: string) => {
-  const trimmedValue = value.trim()
-
-  return (
-    trimmedValue.length > 0 &&
-    trimmedValue !== missingListingIdentityPlaceholder
-  )
-}
-
-const getSaveFailureVehicleName = (listing: ReadyPreparedListing['listing']) =>
-  [listing.vname, listing.vehicleName].find(isUsableListingIdentity) ||
-  listing.vname ||
-  listing.vehicleName
+import { ListingChipInput } from '@/v2/widgets/url-input'
 
 export function TruckHarvesterApp() {
-  const [preparedStore] = useState(() => createPreparedListingStore())
-  const [onboardingStore] = useState(() =>
-    createOnboardingStore({ deferInitialTour: true })
-  )
-  const [directory, setDirectory] = useState<WritableDirectoryHandle | null>(
-    null
-  )
-  const [directoryPermissionState, setDirectoryPermissionState] =
-    useState<DirectoryPermissionState>('ready')
-  const [duplicateMessage, setDuplicateMessage] = useState<string | null>(null)
-  const [fileSystemSupported, setFileSystemSupported] = useState(false)
-  const [isSaving, setIsSaving] = useState(false)
-  const [notificationAvailable, setNotificationAvailable] = useState(false)
-  const [notificationPermission, setNotificationPermission] = useState<
-    NotificationPermission | 'unsupported'
-  >('unsupported')
-  const isMountedRef = useRef(false)
-  const pasteSequenceRef = useRef(0)
-  const previewControllersRef = useRef<Set<AbortController>>(new Set())
-  const saveControllerRef = useRef<AbortController | null>(null)
-  const analyticsBatchByListingIdRef = useRef<Map<string, AnalyticsBatchState>>(
-    new Map()
-  )
-  const saveFailureIdsRef = useRef<Set<string>>(new Set())
-
-  const preparedState = useStore(preparedStore, (state) => state)
-  const onboardingState = useStore(onboardingStore, (state) => state)
-  const readyListings = selectReadyPreparedListings(preparedState)
-  const checkingListings = selectCheckingPreparedListings(preparedState)
-  const inputListings = preparedState.items.filter(
-    (item) => item.status !== 'saved'
-  )
-  const isTourOpen = onboardingState.isTourOpen
-
-  useBrowserLayoutEffect(() => {
-    const supported = isFileSystemAccessAvailable()
-    setFileSystemSupported(supported)
-    setDirectoryPermissionState('ready')
-
-    if (isCompletionNotificationAvailable()) {
-      setNotificationAvailable(true)
-      setNotificationPermission(window.Notification.permission)
-    }
-
-    const frame = requestNextFrame(() => {
-      onboardingStore.getState().initializeTour()
-    })
-
-    return () => {
-      cancelNextFrame(frame)
-    }
-  }, [onboardingStore])
-
-  useEffect(() => {
-    isMountedRef.current = true
-    const previewControllers = previewControllersRef.current
-
-    return () => {
-      isMountedRef.current = false
-      previewControllers.forEach((controller) => controller.abort())
-      previewControllers.clear()
-      saveControllerRef.current?.abort()
-      saveControllerRef.current = null
-    }
-  }, [])
-
-  const resolveSaveDirectoryForRun = async () => {
-    if (!isFileSystemAccessAvailable()) {
-      return null
-    }
-
-    const activeDirectory = directory
-
-    if (activeDirectory) {
-      if (directoryPermissionState === 'denied') {
-        const nextDirectory = await pickSaveDirectory({
-          id: saveFolderPickerId,
-          startIn: 'downloads',
-        })
-
-        if (!nextDirectory) {
-          return undefined
-        }
-
-        if (isMountedRef.current) {
-          setDirectory(nextDirectory)
-          setDirectoryPermissionState('ready')
-        }
-
-        return nextDirectory
-      }
-
-      const hasPermission =
-        await requestWritableDirectoryPermission(activeDirectory)
-
-      if (!hasPermission) {
-        if (isMountedRef.current) {
-          setDirectoryPermissionState('denied')
-        }
-        return undefined
-      }
-
-      if (isMountedRef.current) {
-        setDirectory(activeDirectory)
-        setDirectoryPermissionState('ready')
-      }
-
-      return activeDirectory
-    }
-
-    const nextDirectory = await pickSaveDirectory({
-      id: saveFolderPickerId,
-      startIn: 'downloads',
-    })
-
-    if (!nextDirectory) {
-      return undefined
-    }
-
-    if (isMountedRef.current) {
-      setDirectory(nextDirectory)
-      setDirectoryPermissionState('ready')
-    }
-
-    return nextDirectory
-  }
-
-  const selectDirectory = async (nextDirectory: WritableDirectoryHandle) => {
-    if (isMountedRef.current) {
-      setDirectory(nextDirectory)
-      setDirectoryPermissionState('ready')
-    }
-  }
-
-  const createAnalyticsBatch = (urlCount: number): AnalyticsBatchState => ({
-    id: createAnalyticsBatchId(),
-    startedAt: getAnalyticsNow(),
-    urlCount,
-  })
-
-  const getBatchAnalyticsInput = (
-    batch: AnalyticsBatchState,
-    items: readonly AnalyticsPreviewItem[] = [],
-    saveOptions: BatchAnalyticsSaveOptions = {}
-  ) => {
-    return {
-      batchId: batch.id,
-      urlCount: batch.urlCount,
-      uniqueUrlCount: items.length,
-      readyCount: items.filter((item) => item.status === 'ready').length,
-      invalidCount: items.filter((item) => item.status === 'invalid').length,
-      previewFailedCount: items.filter((item) => item.status === 'failed')
-        .length,
-      savedCount: saveOptions.savedCount ?? 0,
-      saveFailedCount: saveOptions.saveFailedCount ?? 0,
-      durationMs: getAnalyticsDuration(batch.startedAt),
-      saveMethod: saveOptions.saveMethod,
-      filesystemSupported: fileSystemSupported,
-      notificationEnabled: isNotificationEnabled(notificationPermission),
-    }
-  }
-
-  const getAnalyticsPreviewItems = (
-    prepareResult: Awaited<ReturnType<typeof prepareListingUrls>>
-  ) => {
-    const currentItemsById = new Map(
-      preparedStore.getState().items.map((item) => [item.id, item])
-    )
-    const settledItemsById = new Map(
-      prepareResult.settledItems.map((item) => [item.id, item])
-    )
-
-    return prepareResult.addedItems.flatMap<AnalyticsPreviewItem>((runItem) => {
-      const currentItem = currentItemsById.get(runItem.id)
-
-      if (currentItem) {
-        if (currentItem.status === 'ready') {
-          return [
-            {
-              id: currentItem.id,
-              url: currentItem.url,
-              status: 'ready',
-            },
-          ]
-        }
-
-        if (
-          currentItem.status === 'invalid' ||
-          currentItem.status === 'failed'
-        ) {
-          return [
-            {
-              id: currentItem.id,
-              url: currentItem.url,
-              status: currentItem.status,
-              message: currentItem.message,
-            },
-          ]
-        }
-      }
-
-      const settledItem = settledItemsById.get(runItem.id)
-
-      return settledItem ? [settledItem] : []
-    })
-  }
-
-  const getReadyAnalyticsItems = (
-    items: readonly ReadyPreparedListing[]
-  ): AnalyticsPreviewItem[] =>
-    items.map((item) => ({
-      id: item.id,
-      url: item.url,
-      status: 'ready',
-    }))
-
-  const getSaveBatchGroups = (
-    items: readonly ReadyPreparedListing[]
-  ): AnalyticsSaveBatchGroup[] => {
-    const groups: AnalyticsSaveBatchGroup[] = []
-    const groupsByBatchId = new Map<string, AnalyticsSaveBatchGroup>()
-
-    items.forEach((item) => {
-      const batch = analyticsBatchByListingIdRef.current.get(item.id)
-
-      if (!batch) {
-        return
-      }
-
-      const currentGroup = groupsByBatchId.get(batch.id)
-
-      if (currentGroup) {
-        currentGroup.items.push(item)
-        return
-      }
-
-      const nextGroup = { batch, items: [item] }
-
-      groupsByBatchId.set(batch.id, nextGroup)
-      groups.push(nextGroup)
-    })
-
-    return groups
-  }
-
-  const ensureFallbackSaveAnalyticsBatch = (
-    items: readonly ReadyPreparedListing[]
-  ) => {
-    const unmappedItems = items.filter(
-      (item) => !analyticsBatchByListingIdRef.current.has(item.id)
-    )
-
-    if (unmappedItems.length === 0) {
-      return
-    }
-
-    const fallbackBatch = createAnalyticsBatch(unmappedItems.length)
-
-    unmappedItems.forEach((item) => {
-      analyticsBatchByListingIdRef.current.set(item.id, fallbackBatch)
-    })
-  }
-
-  const getSaveBatchCounts = (
-    group: AnalyticsSaveBatchGroup,
-    savedItemIds: ReadonlySet<string>
-  ) => ({
-    savedCount: group.items.filter((item) => savedItemIds.has(item.id)).length,
-    saveFailedCount: group.items.filter((item) =>
-      saveFailureIdsRef.current.has(item.id)
-    ).length,
-  })
-
-  const getSaveBatchAnalyticsInput = (
-    group: AnalyticsSaveBatchGroup,
-    saveMethod: SaveMethod,
-    savedItemIds: ReadonlySet<string>
-  ) =>
-    getBatchAnalyticsInput(group.batch, getReadyAnalyticsItems(group.items), {
-      ...getSaveBatchCounts(group, savedItemIds),
-      saveMethod,
-    })
-
-  const trackSaveListingFailure = (item: ReadyPreparedListing) => {
-    const batch = analyticsBatchByListingIdRef.current.get(item.id)
-
-    if (!batch) {
-      return
-    }
-
-    trackListingFailed({
-      batchId: batch.id,
-      failureStage: 'save',
-      failureReason: saveFailureMessage,
-      listingUrl: item.url,
-      vehicleNumber: item.listing.vnumber,
-      vehicleName: getSaveFailureVehicleName(item.listing),
-      imageCount: item.listing.images.length,
-      elapsedMs: getAnalyticsDuration(batch.startedAt),
-    })
-  }
-
-  const handlePasteText = (text: string) => {
-    const pasteStartedAt = getAnalyticsNow()
-    const pasteSequence = pasteSequenceRef.current + 1
-    pasteSequenceRef.current = pasteSequence
-    const result = parseUrlInputText(text)
-
-    if (!result.success) {
-      if (text.trim().length > 0) {
-        trackUnsupportedInputFailure({
-          batchId: createAnalyticsBatchId(),
-          rawInput: text,
-          elapsedMs: getAnalyticsDuration(pasteStartedAt),
-        })
-      }
-
-      if (isMountedRef.current && pasteSequenceRef.current === pasteSequence) {
-        setDuplicateMessage(result.message)
-      }
-      return
-    }
-
-    const analyticsBatch = createAnalyticsBatch(result.urls.length)
-    trackBatchStarted({
-      ...getBatchAnalyticsInput(analyticsBatch),
-      uniqueUrlCount: result.urls.length,
-    })
-
-    const previewController = new AbortController()
-    previewControllersRef.current.add(previewController)
-
-    void prepareListingUrls({
-      urls: result.urls,
-      store: preparedStore,
-      signal: previewController.signal,
-    })
-      .then((prepareResult) => {
-        if (!isMountedRef.current || previewController.signal.aborted) {
-          return
-        }
-
-        prepareResult.addedItems.forEach((item) => {
-          analyticsBatchByListingIdRef.current.set(item.id, analyticsBatch)
-        })
-
-        const batchItems = getAnalyticsPreviewItems(prepareResult)
-
-        trackPreviewCompleted(
-          getBatchAnalyticsInput(analyticsBatch, batchItems)
-        )
-
-        batchItems.forEach((item) => {
-          if (item.status !== 'invalid' && item.status !== 'failed') {
-            return
-          }
-
-          trackListingFailed({
-            batchId: analyticsBatch.id,
-            failureStage: item.status === 'invalid' ? 'invalid_url' : 'preview',
-            failureReason: item.message,
-            listingUrl: item.url,
-            elapsedMs: getAnalyticsDuration(analyticsBatch.startedAt),
-          })
-        })
-
-        if (pasteSequenceRef.current === pasteSequence) {
-          setDuplicateMessage(
-            prepareResult.duplicates.length > 0 ? '이미 넣은 매물이에요.' : null
-          )
-        }
-      })
-      .catch(() => {
-        // Preview cancellation is expected when leaving the route.
-      })
-      .finally(() => {
-        previewControllersRef.current.delete(previewController)
-      })
-  }
-
-  const requestNotificationPermission = () => {
-    void requestCompletionNotificationPermission().then((permission) => {
-      if (isMountedRef.current) {
-        setNotificationPermission(permission)
-      }
-    })
-  }
-
-  const startSavingReadyListings = async () => {
-    if (isSaving || readyListings.length === 0 || checkingListings.length > 0) {
-      return
-    }
-
-    const controller = new AbortController()
-    saveControllerRef.current?.abort()
-    saveControllerRef.current = controller
-    const canContinueSave = () =>
-      isMountedRef.current && !controller.signal.aborted
-
-    try {
-      const runDirectory = await resolveSaveDirectoryForRun()
-
-      if (!canContinueSave()) {
-        return
-      }
-
-      if (runDirectory === undefined) {
-        return
-      }
-
-      const itemsToSave = readyListings
-      setIsSaving(true)
-
-      const saveMethod: SaveMethod = runDirectory ? 'directory' : 'zip'
-      const savedItemIds = new Set<string>()
-      ensureFallbackSaveAnalyticsBatch(itemsToSave)
-      const saveBatchGroups = getSaveBatchGroups(itemsToSave)
-
-      itemsToSave.forEach((item) => {
-        saveFailureIdsRef.current.delete(item.id)
-      })
-
-      saveBatchGroups.forEach((group) => {
-        trackSaveStarted(
-          getSaveBatchAnalyticsInput(group, saveMethod, savedItemIds)
-        )
-      })
-
-      let savedCount = 0
-
-      if (runDirectory) {
-        for (const item of itemsToSave) {
-          if (!canContinueSave()) {
-            return
-          }
-
-          preparedStore.getState().markSaving(item.id, {
-            downloadedImages: 0,
-            totalImages: item.listing.images.length,
-            progress: 0,
-          })
-
-          try {
-            await saveTruckToDirectory(runDirectory, item.listing, {
-              signal: controller.signal,
-              onProgress: (progress, downloadedImages, totalImages) => {
-                if (!canContinueSave()) {
-                  return
-                }
-
-                preparedStore.getState().markSaving(item.id, {
-                  progress,
-                  downloadedImages,
-                  totalImages,
-                })
-              },
-            })
-
-            if (!canContinueSave()) {
-              return
-            }
-
-            preparedStore.getState().markSaved(item.id)
-            savedItemIds.add(item.id)
-            savedCount += 1
-          } catch {
-            if (!canContinueSave()) {
-              return
-            }
-
-            saveFailureIdsRef.current.add(item.id)
-            trackSaveListingFailure(item)
-            preparedStore.getState().markFailed(item.url, saveFailureMessage)
-          }
-        }
-      } else {
-        itemsToSave.forEach((item) => {
-          preparedStore.getState().markSaving(item.id, {
-            downloadedImages: 0,
-            totalImages: item.listing.images.length,
-            progress: 0,
-          })
-        })
-
-        try {
-          await downloadTruckZip(
-            itemsToSave.map((item) => item.listing),
-            {
-              signal: controller.signal,
-              onProgress: (progress) => {
-                if (!canContinueSave()) {
-                  return
-                }
-
-                itemsToSave.forEach((item) => {
-                  preparedStore.getState().markSaving(item.id, {
-                    progress,
-                    downloadedImages: 0,
-                    totalImages: item.listing.images.length,
-                  })
-                })
-              },
-            }
-          )
-
-          if (!canContinueSave()) {
-            return
-          }
-
-          itemsToSave.forEach((item) => {
-            preparedStore.getState().markSaved(item.id)
-            savedItemIds.add(item.id)
-          })
-          savedCount = itemsToSave.length
-        } catch {
-          if (!canContinueSave()) {
-            return
-          }
-
-          itemsToSave.forEach((item) => {
-            saveFailureIdsRef.current.add(item.id)
-          })
-
-          itemsToSave.forEach((item) => {
-            trackSaveListingFailure(item)
-          })
-
-          itemsToSave.forEach((item) => {
-            preparedStore.getState().markFailed(item.url, saveFailureMessage)
-          })
-        }
-      }
-
-      saveBatchGroups.forEach((group) => {
-        const saveCounts = getSaveBatchCounts(group, savedItemIds)
-        const saveAnalyticsInput = getSaveBatchAnalyticsInput(
-          group,
-          saveMethod,
-          savedItemIds
-        )
-
-        if (saveCounts.savedCount === group.items.length) {
-          trackSaveCompleted(saveAnalyticsInput)
-          return
-        }
-
-        trackSaveFailed(saveAnalyticsInput)
-      })
-
-      if (savedCount > 0 && canContinueSave()) {
-        notifyCompletion(savedCount)
-      }
-    } finally {
-      if (saveControllerRef.current === controller) {
-        saveControllerRef.current = null
-      }
-
-      if (isMountedRef.current) {
-        setIsSaving(false)
-      }
-    }
-  }
-
-  const canRemovePreparedItem = (item: PreparedListing) =>
-    item.status !== 'saving' && item.status !== 'saved'
+  const workflow = useTruckHarvesterWorkflow()
 
   return (
     <main
@@ -699,7 +22,7 @@ export function TruckHarvesterApp() {
       <section
         className="mx-auto grid min-h-dvh w-full max-w-6xl gap-6 px-6 py-8 md:px-10"
         data-tour-background="true"
-        inert={isTourOpen ? true : undefined}
+        inert={workflow.isTourOpen ? true : undefined}
       >
         <header className="flex items-center justify-between gap-4">
           <div>
@@ -711,8 +34,8 @@ export function TruckHarvesterApp() {
             </h1>
           </div>
           <HelpMenuButton
-            disabled={isTourOpen}
-            onRestartTour={onboardingState.restartTour}
+            disabled={workflow.isTourOpen}
+            onRestartTour={workflow.onboardingState.restartTour}
           />
         </header>
 
@@ -720,53 +43,45 @@ export function TruckHarvesterApp() {
           <div className="grid content-start gap-5">
             <div data-tour="url-input">
               <ListingChipInput
-                canRemoveItem={canRemovePreparedItem}
-                disabled={isSaving || isTourOpen}
-                duplicateMessage={duplicateMessage}
-                items={inputListings}
-                onPasteText={handlePasteText}
-                onRemove={(id) => {
-                  analyticsBatchByListingIdRef.current.delete(id)
-                  saveFailureIdsRef.current.delete(id)
-                  preparedStore.getState().remove(id)
-                }}
-                onStart={() => void startSavingReadyListings()}
+                canRemoveItem={workflow.canRemovePreparedItem}
+                disabled={workflow.isSaving || workflow.isTourOpen}
+                duplicateMessage={workflow.duplicateMessage}
+                items={workflow.inputListings}
+                onPasteText={workflow.handlePasteText}
+                onRemove={workflow.removePreparedItem}
+                onStart={() => void workflow.startSavingReadyListings()}
               />
             </div>
           </div>
 
           <div className="grid content-start gap-5">
             <DirectorySelector
-              disabled={isTourOpen}
-              isSupported={fileSystemSupported}
-              onSelectDirectory={selectDirectory}
-              permissionState={directoryPermissionState}
-              pickerStartIn={
-                directoryPermissionState === 'denied'
-                  ? 'downloads'
-                  : (directory ?? 'downloads')
-              }
-              selectedDirectoryName={directory?.name}
+              disabled={workflow.isTourOpen}
+              isSupported={workflow.fileSystemSupported}
+              onSelectDirectory={workflow.selectDirectory}
+              permissionState={workflow.directoryPermissionState}
+              pickerStartIn={workflow.pickerStartIn}
+              selectedDirectoryName={workflow.directory?.name}
             />
             <CompletionNotificationToggle
-              disabled={isTourOpen}
-              isAvailable={notificationAvailable}
-              onEnable={requestNotificationPermission}
-              permission={notificationPermission}
+              disabled={workflow.isTourOpen}
+              isAvailable={workflow.notificationAvailable}
+              onEnable={workflow.requestNotificationPermission}
+              permission={workflow.notificationPermission}
             />
             <div data-tour="processing-status">
-              <PreparedListingStatusPanel items={preparedState.items} />
+              <PreparedListingStatusPanel items={workflow.preparedItems} />
             </div>
           </div>
         </div>
       </section>
 
       <TourOverlay
-        currentStep={onboardingState.currentStep}
-        isOpen={onboardingState.isTourOpen}
-        onClose={onboardingState.completeTour}
-        onNext={() => onboardingState.goToNextStep(tourSteps.length)}
-        onPrevious={onboardingState.goToPreviousStep}
+        currentStep={workflow.onboardingState.currentStep}
+        isOpen={workflow.onboardingState.isTourOpen}
+        onClose={workflow.onboardingState.completeTour}
+        onNext={() => workflow.onboardingState.goToNextStep(tourSteps.length)}
+        onPrevious={workflow.onboardingState.goToPreviousStep}
       />
     </main>
   )

--- a/src/v2/AGENTS.md
+++ b/src/v2/AGENTS.md
@@ -13,12 +13,14 @@ avoid unnecessary import churn after cutover.
 
 ## Layer Map
 
+- `application/`: root app business workflow orchestration, React hook
+  adapters, and workflow analytics boundaries.
 - `design-system/`: token docs and TypeScript helpers for CSS variables.
 - `shared/`: base utilities, UI primitives, stores, and cross-feature
   helpers that do not know about a specific widget.
 - `entities/`: pure domain schemas for truck listings, input addresses,
   downloads, and per-item states.
-- `features/`: business workflows such as parsing, retrying, saving, and
+- `features/`: capabilities such as parsing, retrying, saving, and
   onboarding.
 - `widgets/`: composed UI blocks for the root page.
 

--- a/src/v2/application/AGENTS.md
+++ b/src/v2/application/AGENTS.md
@@ -1,0 +1,28 @@
+# src/v2/application AGENTS.md
+
+`src/v2/application` contains business workflow orchestration for the root
+Truck Harvester app. It coordinates feature capabilities, browser adapters,
+and workflow analytics without owning user-facing widgets.
+
+## Responsibilities
+
+- Own paste-preview-save use cases that span multiple feature slices.
+- Keep business workflow code testable outside React when possible.
+- Keep React lifecycle, abort controllers, and browser permission state inside
+  hook adapters.
+- Convert workflow facts to analytics through a workflow analytics adapter.
+
+## Rules
+
+- Application code may import from `src/v2/entities`, `src/v2/features`, and
+  `src/v2/shared`.
+- Application code must not import widgets.
+- Features, shared helpers, and widgets must not import application code.
+- UI components must not call analytics tracking functions directly.
+- Workflow analytics observes facts and must not mutate prepared listing state.
+
+## Knowledge Links
+
+- Workflow architecture: `docs/architecture.md`
+- Decisions: `docs/decisions/`
+- Runbooks: `docs/runbooks/`

--- a/src/v2/application/index.ts
+++ b/src/v2/application/index.ts
@@ -1,0 +1,1 @@
+export * from './truck-harvester-workflow'

--- a/src/v2/application/truck-harvester-workflow/index.ts
+++ b/src/v2/application/truck-harvester-workflow/index.ts
@@ -1,0 +1,1 @@
+export * from './use-truck-harvester-workflow'

--- a/src/v2/application/truck-harvester-workflow/index.ts
+++ b/src/v2/application/truck-harvester-workflow/index.ts
@@ -1,1 +1,1 @@
-export * from './use-truck-harvester-workflow'
+export {}

--- a/src/v2/application/truck-harvester-workflow/index.ts
+++ b/src/v2/application/truck-harvester-workflow/index.ts
@@ -1,1 +1,1 @@
-export {}
+export * from './use-truck-harvester-workflow'

--- a/src/v2/application/truck-harvester-workflow/preview-workflow.test.ts
+++ b/src/v2/application/truck-harvester-workflow/preview-workflow.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it, vi } from 'vitest'
+import { type StoreApi } from 'zustand/vanilla'
+
+import { type TruckListing } from '@/v2/entities/truck'
+import {
+  createPreparedListingStore,
+  type PreparedListingState,
+} from '@/v2/features/listing-preparation'
+
+import { runPreviewWorkflow } from './preview-workflow'
+import {
+  type AnalyticsBatchRef,
+  type WorkflowTracker,
+} from './workflow-analytics'
+
+const firstUrl =
+  'https://www.truck-no1.co.kr/model/DetailView.asp?ShopNo=1&MemberNo=2&OnCarNo=3'
+
+const listing: TruckListing = {
+  url: firstUrl,
+  vname: '현대 메가트럭',
+  vehicleName: '현대 메가트럭',
+  vnumber: '서울12가3456',
+  price: {
+    raw: 3200,
+    rawWon: 32000000,
+    label: '3,200만원',
+    compactLabel: '3,200만원',
+  },
+  year: '2020',
+  mileage: '120,000km',
+  options: '윙바디',
+  images: [],
+}
+
+const createTracker = () => {
+  const batch: AnalyticsBatchRef = {
+    id: 'batch-1',
+    startedAt: 10,
+    urlCount: 1,
+  }
+
+  return {
+    batch,
+    tracker: {
+      previewCompleted: vi.fn(),
+      previewStarted: vi.fn(() => batch),
+      removeListing: vi.fn(),
+      saveListingFailed: vi.fn(),
+      saveSettled: vi.fn(),
+      saveStarted: vi.fn(),
+      unsupportedInputFailed: vi.fn(),
+    } satisfies WorkflowTracker,
+  }
+}
+
+const runWorkflow = (input: {
+  text: string
+  store: StoreApi<PreparedListingState>
+  parse?: (url: string, signal?: AbortSignal) => Promise<TruckListing>
+  signal?: AbortSignal
+  tracker?: WorkflowTracker
+}) => {
+  const { tracker } = createTracker()
+
+  return runPreviewWorkflow({
+    getStartedAt: () => 10,
+    parse: input.parse ?? (async () => listing),
+    signal: input.signal,
+    store: input.store,
+    text: input.text,
+    tracker: input.tracker ?? tracker,
+  })
+}
+
+describe('runPreviewWorkflow', () => {
+  it('tracks unsupported non-empty input without starting preview', async () => {
+    const store = createPreparedListingStore()
+    const { tracker } = createTracker()
+
+    const result = await runWorkflow({
+      text: 'DetailView.asp?ShopNo=1',
+      store,
+      tracker,
+    })
+
+    expect(result).toEqual({
+      duplicateMessage:
+        '매물 주소를 찾지 못했어요. 복사한 내용을 다시 확인해 주세요.',
+    })
+    expect(tracker.unsupportedInputFailed).toHaveBeenCalledWith({
+      rawInput: 'DetailView.asp?ShopNo=1',
+      startedAt: 10,
+    })
+    expect(tracker.previewStarted).not.toHaveBeenCalled()
+  })
+
+  it('does not track whitespace input', async () => {
+    const store = createPreparedListingStore()
+    const { tracker } = createTracker()
+
+    await runWorkflow({
+      text: ' \n\t ',
+      store,
+      tracker,
+    })
+
+    expect(tracker.unsupportedInputFailed).not.toHaveBeenCalled()
+    expect(tracker.previewStarted).not.toHaveBeenCalled()
+  })
+
+  it('adds supported URLs, previews them, and reports preview completion', async () => {
+    const store = createPreparedListingStore()
+    const { batch, tracker } = createTracker()
+
+    const result = await runWorkflow({
+      text: firstUrl,
+      store,
+      tracker,
+    })
+
+    expect(result).toEqual({ duplicateMessage: null })
+    expect(store.getState().items[0]).toMatchObject({
+      id: 'listing-1',
+      status: 'ready',
+      url: firstUrl,
+    })
+    expect(tracker.previewStarted).toHaveBeenCalledWith({
+      urlCount: 1,
+      startedAt: 10,
+    })
+    expect(tracker.previewCompleted).toHaveBeenCalledWith({
+      batch,
+      items: [{ id: 'listing-1', url: firstUrl, status: 'ready' }],
+    })
+  })
+
+  it('returns the duplicate helper message for duplicate pasted addresses', async () => {
+    const store = createPreparedListingStore()
+
+    await runWorkflow({ text: firstUrl, store })
+    const result = await runWorkflow({ text: firstUrl, store })
+
+    expect(result).toEqual({ duplicateMessage: '이미 넣은 매물이에요.' })
+  })
+
+  it('passes preview failures to workflow analytics', async () => {
+    const store = createPreparedListingStore()
+    const { tracker } = createTracker()
+
+    await runWorkflow({
+      text: firstUrl,
+      store,
+      tracker,
+      parse: async () => {
+        throw new Error('network failed')
+      },
+    })
+
+    expect(tracker.previewCompleted).toHaveBeenCalledWith(
+      expect.objectContaining({
+        items: [
+          {
+            id: 'listing-1',
+            message:
+              '매물 이름을 확인하지 못했어요. 잠시 후 다시 붙여넣어 주세요.',
+            status: 'failed',
+            url: firstUrl,
+          },
+        ],
+      })
+    )
+  })
+
+  it('does not report preview completion after cancellation', async () => {
+    const store = createPreparedListingStore()
+    const controller = new AbortController()
+    const { tracker } = createTracker()
+
+    const result = await runWorkflow({
+      text: firstUrl,
+      store,
+      tracker,
+      signal: controller.signal,
+      parse: async () => {
+        controller.abort()
+        return listing
+      },
+    })
+
+    expect(result).toEqual({ duplicateMessage: null })
+    expect(tracker.previewStarted).toHaveBeenCalledWith({
+      urlCount: 1,
+      startedAt: 10,
+    })
+    expect(tracker.previewCompleted).not.toHaveBeenCalled()
+  })
+})

--- a/src/v2/application/truck-harvester-workflow/preview-workflow.test.ts
+++ b/src/v2/application/truck-harvester-workflow/preview-workflow.test.ts
@@ -135,6 +135,26 @@ describe('runPreviewWorkflow', () => {
     })
   })
 
+  it('does not start preview analytics when already cancelled', async () => {
+    const store = createPreparedListingStore()
+    const controller = new AbortController()
+    const { tracker } = createTracker()
+
+    controller.abort()
+
+    const result = await runWorkflow({
+      text: firstUrl,
+      store,
+      tracker,
+      signal: controller.signal,
+    })
+
+    expect(result).toEqual({ duplicateMessage: null })
+    expect(tracker.previewStarted).not.toHaveBeenCalled()
+    expect(tracker.previewCompleted).not.toHaveBeenCalled()
+    expect(store.getState().items).toEqual([])
+  })
+
   it('returns the duplicate helper message for duplicate pasted addresses', async () => {
     const store = createPreparedListingStore()
 

--- a/src/v2/application/truck-harvester-workflow/preview-workflow.ts
+++ b/src/v2/application/truck-harvester-workflow/preview-workflow.ts
@@ -1,0 +1,97 @@
+import { type StoreApi } from 'zustand/vanilla'
+
+import { type TruckListing } from '@/v2/entities/truck'
+import {
+  parseUrlInputText,
+  prepareListingUrls,
+  type PreparedListingSettledItem,
+  type PreparedListingState,
+} from '@/v2/features/listing-preparation'
+
+import {
+  type WorkflowPreviewItem,
+  type WorkflowTracker,
+} from './workflow-analytics'
+
+interface RunPreviewWorkflowInput {
+  getStartedAt?: () => number
+  parse?: (url: string, signal?: AbortSignal) => Promise<TruckListing>
+  signal?: AbortSignal
+  store: StoreApi<PreparedListingState>
+  text: string
+  tracker: WorkflowTracker
+}
+
+interface RunPreviewWorkflowResult {
+  duplicateMessage: string | null
+}
+
+const duplicateMessage = '이미 넣은 매물이에요.'
+
+const toWorkflowPreviewItem = (
+  item: PreparedListingSettledItem
+): WorkflowPreviewItem => {
+  if (item.status === 'ready') {
+    return {
+      id: item.id,
+      url: item.url,
+      status: 'ready',
+    }
+  }
+
+  return {
+    id: item.id,
+    url: item.url,
+    status: item.status,
+    message: item.message,
+  }
+}
+
+export async function runPreviewWorkflow({
+  getStartedAt = () =>
+    typeof performance !== 'undefined' ? performance.now() : Date.now(),
+  parse,
+  signal,
+  store,
+  text,
+  tracker,
+}: RunPreviewWorkflowInput): Promise<RunPreviewWorkflowResult> {
+  const startedAt = getStartedAt()
+  const input = parseUrlInputText(text)
+
+  if (!input.success) {
+    if (text.trim().length > 0) {
+      tracker.unsupportedInputFailed({
+        rawInput: text,
+        startedAt,
+      })
+    }
+
+    return { duplicateMessage: input.message }
+  }
+
+  const batch = tracker.previewStarted({
+    urlCount: input.urls.length,
+    startedAt,
+  })
+
+  const result = await prepareListingUrls({
+    urls: input.urls,
+    store,
+    signal,
+    parse,
+  })
+
+  if (signal?.aborted) {
+    return { duplicateMessage: null }
+  }
+
+  tracker.previewCompleted({
+    batch,
+    items: result.settledItems.map(toWorkflowPreviewItem),
+  })
+
+  return {
+    duplicateMessage: result.duplicates.length > 0 ? duplicateMessage : null,
+  }
+}

--- a/src/v2/application/truck-harvester-workflow/preview-workflow.ts
+++ b/src/v2/application/truck-harvester-workflow/preview-workflow.ts
@@ -70,6 +70,10 @@ export async function runPreviewWorkflow({
     return { duplicateMessage: input.message }
   }
 
+  if (signal?.aborted) {
+    return { duplicateMessage: null }
+  }
+
   const batch = tracker.previewStarted({
     urlCount: input.urls.length,
     startedAt,

--- a/src/v2/application/truck-harvester-workflow/save-workflow.test.ts
+++ b/src/v2/application/truck-harvester-workflow/save-workflow.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it, vi } from 'vitest'
+import { type StoreApi } from 'zustand/vanilla'
+
+import { type TruckListing } from '@/v2/entities/truck'
+import { type WritableDirectoryHandle } from '@/v2/features/file-management'
+import {
+  createPreparedListingStore,
+  type PreparedListingState,
+  type ReadyPreparedListing,
+} from '@/v2/features/listing-preparation'
+
+import { runSaveWorkflow } from './save-workflow'
+import { type WorkflowTracker } from './workflow-analytics'
+
+const firstUrl =
+  'https://www.truck-no1.co.kr/model/DetailView.asp?ShopNo=1&MemberNo=2&OnCarNo=3'
+
+const secondUrl = `${firstUrl}&copy=2`
+
+const listing: TruckListing = {
+  url: firstUrl,
+  vname: '현대 메가트럭',
+  vehicleName: '현대 메가트럭',
+  vnumber: '서울12가3456',
+  price: {
+    raw: 3200,
+    rawWon: 32000000,
+    label: '3,200만원',
+    compactLabel: '3,200만원',
+  },
+  year: '2020',
+  mileage: '120,000km',
+  options: '윙바디',
+  images: [],
+}
+
+const saveFailureMessage =
+  '저장하지 못했어요. 저장 폴더와 인터넷 연결을 확인한 뒤 다시 시도해 주세요.'
+
+const createTracker = () =>
+  ({
+    previewCompleted: vi.fn(),
+    previewStarted: vi.fn(),
+    removeListing: vi.fn(),
+    saveListingFailed: vi.fn(),
+    saveSettled: vi.fn(),
+    saveStarted: vi.fn(),
+    unsupportedInputFailed: vi.fn(),
+  }) satisfies WorkflowTracker
+
+const createDirectory = () =>
+  ({
+    getDirectoryHandle: vi.fn(),
+    getFileHandle: vi.fn(),
+  }) satisfies WritableDirectoryHandle
+
+const addReadyListings = (
+  store: StoreApi<PreparedListingState>,
+  listings: readonly TruckListing[] = [listing]
+) => {
+  store.getState().addUrls(listings.map((item) => item.url))
+  listings.forEach((item) => {
+    store.getState().markReady(item.url, item)
+  })
+
+  return store.getState().items as ReadyPreparedListing[]
+}
+
+describe('runSaveWorkflow', () => {
+  it('saves ready listings to a directory and settles with saved ids', async () => {
+    const store = createPreparedListingStore()
+    const items = addReadyListings(store)
+    const tracker = createTracker()
+    const saveTruckToDirectory = vi.fn(async () => undefined)
+    const workflowItem = {
+      id: 'listing-1',
+      url: firstUrl,
+      listing,
+    }
+
+    const result = await runSaveWorkflow({
+      directory: createDirectory(),
+      items,
+      saveMethod: 'directory',
+      saveTruckToDirectory,
+      store,
+      tracker,
+    })
+
+    expect(result).toEqual({ savedCount: 1 })
+    expect(store.getState().items[0]).toMatchObject({
+      status: 'saved',
+      id: 'listing-1',
+      progress: 100,
+    })
+    expect(tracker.saveStarted).toHaveBeenCalledWith({
+      items: [workflowItem],
+      saveMethod: 'directory',
+    })
+    expect(tracker.saveSettled).toHaveBeenCalledWith({
+      items: [workflowItem],
+      saveMethod: 'directory',
+      savedItemIds: new Set(['listing-1']),
+    })
+  })
+
+  it('marks directory save failures and reports the failed listing', async () => {
+    const store = createPreparedListingStore()
+    const items = addReadyListings(store)
+    const tracker = createTracker()
+    const saveTruckToDirectory = vi.fn(async () => {
+      throw new Error('directory unavailable')
+    })
+    const workflowItem = {
+      id: 'listing-1',
+      url: firstUrl,
+      listing,
+    }
+
+    const result = await runSaveWorkflow({
+      directory: createDirectory(),
+      items,
+      saveMethod: 'directory',
+      saveTruckToDirectory,
+      store,
+      tracker,
+    })
+
+    expect(result).toEqual({ savedCount: 0 })
+    expect(store.getState().items[0]).toMatchObject({
+      status: 'failed',
+      id: 'listing-1',
+      message: saveFailureMessage,
+    })
+    expect(tracker.saveListingFailed).toHaveBeenCalledWith({
+      item: workflowItem,
+      message: saveFailureMessage,
+    })
+    expect(tracker.saveSettled).toHaveBeenCalledWith({
+      items: [workflowItem],
+      saveMethod: 'directory',
+      savedItemIds: new Set(),
+    })
+  })
+
+  it('falls back to ZIP saving when no directory is available', async () => {
+    const store = createPreparedListingStore()
+    const items = addReadyListings(store)
+    const tracker = createTracker()
+    const downloadTruckZip = vi.fn(async () => undefined)
+
+    const result = await runSaveWorkflow({
+      directory: null,
+      downloadTruckZip,
+      items,
+      saveMethod: 'zip',
+      store,
+      tracker,
+    })
+
+    expect(result).toEqual({ savedCount: 1 })
+    expect(downloadTruckZip).toHaveBeenCalledWith([listing], {
+      signal: undefined,
+      onProgress: expect.any(Function),
+    })
+    expect(store.getState().items[0]).toMatchObject({
+      status: 'saved',
+      id: 'listing-1',
+      progress: 100,
+    })
+  })
+
+  it('marks all ready listings failed when ZIP saving fails', async () => {
+    const store = createPreparedListingStore()
+    const secondListing = {
+      ...listing,
+      url: secondUrl,
+      vnumber: '부산34나7890',
+    }
+    const items = addReadyListings(store, [listing, secondListing])
+    const tracker = createTracker()
+    const downloadTruckZip = vi.fn(async () => {
+      throw new Error('zip unavailable')
+    })
+
+    const result = await runSaveWorkflow({
+      downloadTruckZip,
+      items,
+      saveMethod: 'zip',
+      store,
+      tracker,
+    })
+
+    expect(result).toEqual({ savedCount: 0 })
+    expect(store.getState().items).toMatchObject([
+      {
+        status: 'failed',
+        id: 'listing-1',
+        message: saveFailureMessage,
+      },
+      {
+        status: 'failed',
+        id: 'listing-2',
+        message: saveFailureMessage,
+      },
+    ])
+    expect(tracker.saveListingFailed).toHaveBeenCalledTimes(2)
+    expect(tracker.saveListingFailed).toHaveBeenCalledWith({
+      item: {
+        id: 'listing-1',
+        url: firstUrl,
+        listing,
+      },
+      message: saveFailureMessage,
+    })
+    expect(tracker.saveListingFailed).toHaveBeenCalledWith({
+      item: {
+        id: 'listing-2',
+        url: secondUrl,
+        listing: secondListing,
+      },
+      message: saveFailureMessage,
+    })
+  })
+
+  it('does not report save settlement or failure after cancellation', async () => {
+    const store = createPreparedListingStore()
+    const items = addReadyListings(store)
+    const tracker = createTracker()
+    const controller = new AbortController()
+    const saveTruckToDirectory = vi.fn(async () => {
+      controller.abort()
+      throw new DOMException('다운로드가 취소되었습니다.', 'AbortError')
+    })
+
+    const result = await runSaveWorkflow({
+      directory: createDirectory(),
+      items,
+      saveMethod: 'directory',
+      saveTruckToDirectory,
+      signal: controller.signal,
+      store,
+      tracker,
+    })
+
+    expect(result).toEqual({ savedCount: 0 })
+    expect(store.getState().items[0]).toMatchObject({
+      status: 'saving',
+      id: 'listing-1',
+    })
+    expect(tracker.saveStarted).toHaveBeenCalled()
+    expect(tracker.saveListingFailed).not.toHaveBeenCalled()
+    expect(tracker.saveSettled).not.toHaveBeenCalled()
+  })
+})

--- a/src/v2/application/truck-harvester-workflow/save-workflow.ts
+++ b/src/v2/application/truck-harvester-workflow/save-workflow.ts
@@ -1,0 +1,183 @@
+import { type StoreApi } from 'zustand/vanilla'
+
+import {
+  downloadTruckZip as defaultDownloadTruckZip,
+  saveTruckToDirectory as defaultSaveTruckToDirectory,
+  type WritableDirectoryHandle,
+} from '@/v2/features/file-management'
+import {
+  type PreparedListingSaveProgress,
+  type PreparedListingState,
+  type ReadyPreparedListing,
+} from '@/v2/features/listing-preparation'
+import { type SaveMethod } from '@/v2/shared/lib/analytics'
+
+import {
+  type WorkflowSaveItem,
+  type WorkflowTracker,
+} from './workflow-analytics'
+
+export interface RunSaveWorkflowInput {
+  directory?: WritableDirectoryHandle | null
+  downloadTruckZip?: typeof defaultDownloadTruckZip
+  items: readonly ReadyPreparedListing[]
+  saveMethod: SaveMethod
+  saveTruckToDirectory?: typeof defaultSaveTruckToDirectory
+  signal?: AbortSignal
+  store: StoreApi<PreparedListingState>
+  tracker: WorkflowTracker
+}
+
+export interface RunSaveWorkflowResult {
+  savedCount: number
+}
+
+const saveFailureMessage =
+  '저장하지 못했어요. 저장 폴더와 인터넷 연결을 확인한 뒤 다시 시도해 주세요.'
+
+const toWorkflowSaveItem = (item: ReadyPreparedListing): WorkflowSaveItem => ({
+  id: item.id,
+  url: item.url,
+  listing: item.listing,
+})
+
+const getInitialProgress = (
+  item: ReadyPreparedListing
+): PreparedListingSaveProgress => ({
+  downloadedImages: 0,
+  totalImages: item.listing.images.length,
+  progress: 0,
+})
+
+const isAborted = (signal?: AbortSignal) => signal?.aborted === true
+
+export async function runSaveWorkflow({
+  directory,
+  downloadTruckZip = defaultDownloadTruckZip,
+  items,
+  saveMethod,
+  saveTruckToDirectory = defaultSaveTruckToDirectory,
+  signal,
+  store,
+  tracker,
+}: RunSaveWorkflowInput): Promise<RunSaveWorkflowResult> {
+  let savedCount = 0
+
+  if (isAborted(signal) || items.length === 0) {
+    return { savedCount }
+  }
+
+  const workflowItems = items.map(toWorkflowSaveItem)
+  const savedItemIds = new Set<string>()
+
+  tracker.saveStarted({ items: workflowItems, saveMethod })
+
+  if (saveMethod === 'directory' && directory) {
+    for (const [index, item] of items.entries()) {
+      if (isAborted(signal)) {
+        return { savedCount }
+      }
+
+      const workflowItem = workflowItems[index]
+
+      store.getState().markSaving(item.id, getInitialProgress(item))
+
+      try {
+        await saveTruckToDirectory(directory, item.listing, {
+          signal,
+          onProgress: (progress, downloadedImages, totalImages) => {
+            if (isAborted(signal)) {
+              return
+            }
+
+            store.getState().markSaving(item.id, {
+              downloadedImages,
+              totalImages,
+              progress,
+            })
+          },
+        })
+
+        if (isAborted(signal)) {
+          return { savedCount }
+        }
+
+        store.getState().markSaved(item.id)
+        savedItemIds.add(item.id)
+        savedCount += 1
+      } catch {
+        if (isAborted(signal)) {
+          return { savedCount }
+        }
+
+        tracker.saveListingFailed({
+          item: workflowItem,
+          message: saveFailureMessage,
+        })
+        store.getState().markFailed(item.url, saveFailureMessage)
+      }
+    }
+  } else {
+    items.forEach((item) => {
+      store.getState().markSaving(item.id, getInitialProgress(item))
+    })
+
+    try {
+      await downloadTruckZip(
+        items.map((item) => item.listing),
+        {
+          signal,
+          onProgress: (progress) => {
+            if (isAborted(signal)) {
+              return
+            }
+
+            items.forEach((item) => {
+              store.getState().markSaving(item.id, {
+                downloadedImages: 0,
+                totalImages: item.listing.images.length,
+                progress,
+              })
+            })
+          },
+        }
+      )
+
+      if (isAborted(signal)) {
+        return { savedCount }
+      }
+
+      items.forEach((item) => {
+        store.getState().markSaved(item.id)
+        savedItemIds.add(item.id)
+      })
+      savedCount = items.length
+    } catch {
+      if (isAborted(signal)) {
+        return { savedCount }
+      }
+
+      workflowItems.forEach((item) => {
+        tracker.saveListingFailed({
+          item,
+          message: saveFailureMessage,
+        })
+      })
+      items.forEach((item) => {
+        store.getState().markFailed(item.url, saveFailureMessage)
+      })
+    }
+  }
+
+  if (isAborted(signal)) {
+    return { savedCount }
+  }
+
+  tracker.saveSettled({
+    items: workflowItems,
+    saveMethod,
+    savedItemIds,
+  })
+
+  return { savedCount }
+}

--- a/src/v2/application/truck-harvester-workflow/use-truck-harvester-workflow.ts
+++ b/src/v2/application/truck-harvester-workflow/use-truck-harvester-workflow.ts
@@ -38,10 +38,6 @@ const useBrowserLayoutEffect =
 type DirectoryPermissionState = 'denied' | 'ready'
 type DirectoryPickerStartIn = WritableDirectoryHandle | 'downloads'
 
-interface HandlePasteTextInput {
-  text: string
-}
-
 const pickSaveDirectory = pickWritableDirectory as (options: {
   id: string
   startIn: DirectoryPickerStartIn
@@ -228,7 +224,7 @@ export function useTruckHarvesterWorkflow() {
     }
   }
 
-  const handlePasteText = ({ text }: HandlePasteTextInput) => {
+  const handlePasteText = (text: string) => {
     const tracker = getTracker()
     const pasteStartedAt = getWorkflowNow()
     const pasteSequence = pasteSequenceRef.current + 1

--- a/src/v2/application/truck-harvester-workflow/use-truck-harvester-workflow.ts
+++ b/src/v2/application/truck-harvester-workflow/use-truck-harvester-workflow.ts
@@ -1,0 +1,356 @@
+'use client'
+
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+
+import { useStore } from 'zustand'
+
+import {
+  isCompletionNotificationAvailable,
+  notifyCompletion,
+  requestCompletionNotificationPermission,
+} from '@/v2/features/completion-notification'
+import {
+  isFileSystemAccessAvailable,
+  pickWritableDirectory,
+  requestWritableDirectoryPermission,
+  type WritableDirectoryHandle,
+} from '@/v2/features/file-management'
+import {
+  createPreparedListingStore,
+  selectCheckingPreparedListings,
+  selectReadyPreparedListings,
+  type PreparedListing,
+} from '@/v2/features/listing-preparation'
+import { type SaveMethod } from '@/v2/shared/lib/analytics'
+import { createOnboardingStore } from '@/v2/shared/model'
+
+import { runPreviewWorkflow } from './preview-workflow'
+import { runSaveWorkflow } from './save-workflow'
+import {
+  createWorkflowAnalytics,
+  type WorkflowTracker,
+} from './workflow-analytics'
+
+const saveFolderPickerId = 'truck-harvester-v2-save-folder'
+const useBrowserLayoutEffect =
+  typeof window === 'undefined' ? useEffect : useLayoutEffect
+
+type DirectoryPermissionState = 'denied' | 'ready'
+type DirectoryPickerStartIn = WritableDirectoryHandle | 'downloads'
+
+interface HandlePasteTextInput {
+  text: string
+}
+
+const pickSaveDirectory = pickWritableDirectory as (options: {
+  id: string
+  startIn: DirectoryPickerStartIn
+}) => Promise<WritableDirectoryHandle | undefined>
+
+const requestNextFrame = (callback: () => void) => {
+  if (
+    typeof window !== 'undefined' &&
+    typeof window.requestAnimationFrame === 'function'
+  ) {
+    return window.requestAnimationFrame(callback)
+  }
+
+  return window.setTimeout(callback, 16)
+}
+
+const cancelNextFrame = (handle: number) => {
+  if (
+    typeof window !== 'undefined' &&
+    typeof window.cancelAnimationFrame === 'function'
+  ) {
+    window.cancelAnimationFrame(handle)
+    return
+  }
+
+  window.clearTimeout(handle)
+}
+
+const getWorkflowNow = () =>
+  typeof performance !== 'undefined' ? performance.now() : Date.now()
+
+const isNotificationEnabled = (
+  permission: NotificationPermission | 'unsupported'
+) => permission === 'granted'
+
+export function useTruckHarvesterWorkflow() {
+  const [preparedStore] = useState(() => createPreparedListingStore())
+  const [onboardingStore] = useState(() =>
+    createOnboardingStore({ deferInitialTour: true })
+  )
+  const [directory, setDirectory] = useState<WritableDirectoryHandle | null>(
+    null
+  )
+  const [directoryPermissionState, setDirectoryPermissionState] =
+    useState<DirectoryPermissionState>('ready')
+  const [duplicateMessage, setDuplicateMessage] = useState<string | null>(null)
+  const [fileSystemSupported, setFileSystemSupported] = useState(false)
+  const [isSaving, setIsSaving] = useState(false)
+  const [notificationAvailable, setNotificationAvailable] = useState(false)
+  const [notificationPermission, setNotificationPermission] = useState<
+    NotificationPermission | 'unsupported'
+  >('unsupported')
+  const isMountedRef = useRef(false)
+  const pasteSequenceRef = useRef(0)
+  const previewControllersRef = useRef<Set<AbortController>>(new Set())
+  const saveControllerRef = useRef<AbortController | null>(null)
+  const fileSystemSupportedRef = useRef(false)
+  const notificationEnabledRef = useRef(false)
+  const trackerRef = useRef<WorkflowTracker | null>(null)
+
+  const preparedState = useStore(preparedStore, (state) => state)
+  const onboardingState = useStore(onboardingStore, (state) => state)
+  const readyListings = selectReadyPreparedListings(preparedState)
+  const checkingListings = selectCheckingPreparedListings(preparedState)
+  const preparedItems = preparedState.items
+  const inputListings = preparedItems.filter((item) => item.status !== 'saved')
+  const isTourOpen = onboardingState.isTourOpen
+  const pickerStartIn: DirectoryPickerStartIn =
+    directoryPermissionState === 'denied'
+      ? 'downloads'
+      : (directory ?? 'downloads')
+
+  const getTracker = () => {
+    trackerRef.current ??= createWorkflowAnalytics({
+      getFilesystemSupported: () => fileSystemSupportedRef.current,
+      getNotificationEnabled: () => notificationEnabledRef.current,
+    })
+
+    return trackerRef.current
+  }
+
+  useBrowserLayoutEffect(() => {
+    getTracker()
+
+    const supported = isFileSystemAccessAvailable()
+    fileSystemSupportedRef.current = supported
+    setFileSystemSupported(supported)
+    setDirectoryPermissionState('ready')
+
+    if (isCompletionNotificationAvailable()) {
+      const permission = window.Notification.permission
+      notificationEnabledRef.current = isNotificationEnabled(permission)
+      setNotificationAvailable(true)
+      setNotificationPermission(permission)
+    }
+
+    const frame = requestNextFrame(() => {
+      onboardingStore.getState().initializeTour()
+    })
+
+    return () => {
+      cancelNextFrame(frame)
+    }
+  }, [onboardingStore])
+
+  useEffect(() => {
+    isMountedRef.current = true
+    const previewControllers = previewControllersRef.current
+
+    return () => {
+      isMountedRef.current = false
+      previewControllers.forEach((controller) => controller.abort())
+      previewControllers.clear()
+      saveControllerRef.current?.abort()
+      saveControllerRef.current = null
+    }
+  }, [])
+
+  const resolveSaveDirectoryForRun = async () => {
+    if (!isFileSystemAccessAvailable()) {
+      return null
+    }
+
+    const activeDirectory = directory
+
+    if (activeDirectory) {
+      if (directoryPermissionState === 'denied') {
+        const nextDirectory = await pickSaveDirectory({
+          id: saveFolderPickerId,
+          startIn: 'downloads',
+        })
+
+        if (!nextDirectory) {
+          return undefined
+        }
+
+        if (isMountedRef.current) {
+          setDirectory(nextDirectory)
+          setDirectoryPermissionState('ready')
+        }
+
+        return nextDirectory
+      }
+
+      const hasPermission =
+        await requestWritableDirectoryPermission(activeDirectory)
+
+      if (!hasPermission) {
+        if (isMountedRef.current) {
+          setDirectoryPermissionState('denied')
+        }
+        return undefined
+      }
+
+      if (isMountedRef.current) {
+        setDirectory(activeDirectory)
+        setDirectoryPermissionState('ready')
+      }
+
+      return activeDirectory
+    }
+
+    const nextDirectory = await pickSaveDirectory({
+      id: saveFolderPickerId,
+      startIn: 'downloads',
+    })
+
+    if (!nextDirectory) {
+      return undefined
+    }
+
+    if (isMountedRef.current) {
+      setDirectory(nextDirectory)
+      setDirectoryPermissionState('ready')
+    }
+
+    return nextDirectory
+  }
+
+  const selectDirectory = async (nextDirectory: WritableDirectoryHandle) => {
+    if (isMountedRef.current) {
+      setDirectory(nextDirectory)
+      setDirectoryPermissionState('ready')
+    }
+  }
+
+  const handlePasteText = ({ text }: HandlePasteTextInput) => {
+    const tracker = getTracker()
+    const pasteStartedAt = getWorkflowNow()
+    const pasteSequence = pasteSequenceRef.current + 1
+    pasteSequenceRef.current = pasteSequence
+    const previewController = new AbortController()
+
+    previewControllersRef.current.add(previewController)
+
+    void runPreviewWorkflow({
+      getStartedAt: () => pasteStartedAt,
+      signal: previewController.signal,
+      store: preparedStore,
+      text,
+      tracker,
+    })
+      .then((result) => {
+        if (
+          !isMountedRef.current ||
+          previewController.signal.aborted ||
+          pasteSequenceRef.current !== pasteSequence
+        ) {
+          return
+        }
+
+        setDuplicateMessage(result.duplicateMessage)
+      })
+      .catch(() => {
+        // Preview cancellation is expected when leaving the route.
+      })
+      .finally(() => {
+        previewControllersRef.current.delete(previewController)
+      })
+  }
+
+  const requestNotificationPermission = () => {
+    void requestCompletionNotificationPermission().then((permission) => {
+      notificationEnabledRef.current = isNotificationEnabled(permission)
+
+      if (isMountedRef.current) {
+        setNotificationPermission(permission)
+      }
+    })
+  }
+
+  const startSavingReadyListings = async () => {
+    if (isSaving || readyListings.length === 0 || checkingListings.length > 0) {
+      return
+    }
+
+    const controller = new AbortController()
+    const tracker = getTracker()
+    saveControllerRef.current?.abort()
+    saveControllerRef.current = controller
+    const canContinueSave = () =>
+      isMountedRef.current && !controller.signal.aborted
+
+    try {
+      const runDirectory = await resolveSaveDirectoryForRun()
+
+      if (!canContinueSave()) {
+        return
+      }
+
+      if (runDirectory === undefined) {
+        return
+      }
+
+      const itemsToSave = readyListings
+      const saveMethod: SaveMethod = runDirectory ? 'directory' : 'zip'
+      setIsSaving(true)
+
+      const { savedCount } = await runSaveWorkflow({
+        directory: runDirectory,
+        items: itemsToSave,
+        saveMethod,
+        signal: controller.signal,
+        store: preparedStore,
+        tracker,
+      })
+
+      if (savedCount > 0 && canContinueSave()) {
+        notifyCompletion(savedCount)
+      }
+    } finally {
+      if (saveControllerRef.current === controller) {
+        saveControllerRef.current = null
+      }
+
+      if (isMountedRef.current) {
+        setIsSaving(false)
+      }
+    }
+  }
+
+  const removePreparedItem = (id: string) => {
+    const tracker = getTracker()
+
+    tracker.removeListing(id)
+    preparedStore.getState().remove(id)
+  }
+
+  const canRemovePreparedItem = (item: PreparedListing) =>
+    item.status !== 'saving' && item.status !== 'saved'
+
+  return {
+    canRemovePreparedItem,
+    directory,
+    directoryPermissionState,
+    duplicateMessage,
+    fileSystemSupported,
+    handlePasteText,
+    inputListings,
+    isSaving,
+    isTourOpen,
+    notificationAvailable,
+    notificationPermission,
+    onboardingState,
+    pickerStartIn,
+    preparedItems,
+    removePreparedItem,
+    requestNotificationPermission,
+    selectDirectory,
+    startSavingReadyListings,
+  }
+}

--- a/src/v2/application/truck-harvester-workflow/workflow-analytics.test.ts
+++ b/src/v2/application/truck-harvester-workflow/workflow-analytics.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { type TruckListing } from '@/v2/entities/truck'
+
+import { createWorkflowAnalytics } from './workflow-analytics'
+
+const firstUrl =
+  'https://www.truck-no1.co.kr/model/DetailView.asp?ShopNo=1&MemberNo=2&OnCarNo=3'
+
+const listing: TruckListing = {
+  url: firstUrl,
+  vname: '현대 메가트럭',
+  vehicleName: '현대 메가트럭',
+  vnumber: '서울12가3456',
+  price: {
+    raw: 3200,
+    rawWon: 32000000,
+    label: '3,200만원',
+    compactLabel: '3,200만원',
+  },
+  year: '2020',
+  mileage: '120,000km',
+  options: '윙바디',
+  images: ['https://img.example.com/1.jpg'],
+}
+
+const createTransport = () => ({
+  trackBatchStarted: vi.fn(),
+  trackListingFailed: vi.fn(),
+  trackPreviewCompleted: vi.fn(),
+  trackSaveCompleted: vi.fn(),
+  trackSaveFailed: vi.fn(),
+  trackSaveStarted: vi.fn(),
+  trackUnsupportedInputFailure: vi.fn(),
+})
+
+describe('workflow analytics adapter', () => {
+  it('tracks unsupported input without exposing Umami details to callers', () => {
+    const transport = createTransport()
+    const tracker = createWorkflowAnalytics({
+      createBatchId: () => 'batch-unsupported',
+      getFilesystemSupported: () => true,
+      getNotificationEnabled: () => false,
+      now: () => 15,
+      transport,
+    })
+
+    tracker.unsupportedInputFailed({
+      rawInput: '  DetailView.asp?ShopNo=1  ',
+      startedAt: 5,
+    })
+
+    expect(transport.trackUnsupportedInputFailure).toHaveBeenCalledWith({
+      batchId: 'batch-unsupported',
+      rawInput: '  DetailView.asp?ShopNo=1  ',
+      elapsedMs: 10,
+    })
+    expect(transport.trackBatchStarted).not.toHaveBeenCalled()
+  })
+
+  it('tracks preview start and completion using aggregate counts only', () => {
+    const transport = createTransport()
+    const tracker = createWorkflowAnalytics({
+      createBatchId: () => 'batch-preview',
+      getFilesystemSupported: () => true,
+      getNotificationEnabled: () => true,
+      now: () => 100,
+      transport,
+    })
+
+    const batch = tracker.previewStarted({ urlCount: 2, startedAt: 25 })
+
+    tracker.previewCompleted({
+      batch,
+      items: [
+        { id: 'listing-1', url: firstUrl, status: 'ready' },
+        {
+          id: 'listing-2',
+          url: `${firstUrl}&copy=2`,
+          status: 'failed',
+          message: '매물 이름을 확인하지 못했어요.',
+        },
+      ],
+    })
+
+    expect(transport.trackBatchStarted).toHaveBeenCalledWith(
+      expect.objectContaining({
+        batchId: 'batch-preview',
+        urlCount: 2,
+        uniqueUrlCount: 2,
+        readyCount: 0,
+      })
+    )
+    expect(transport.trackPreviewCompleted).toHaveBeenCalledWith(
+      expect.objectContaining({
+        batchId: 'batch-preview',
+        urlCount: 2,
+        uniqueUrlCount: 2,
+        readyCount: 1,
+        previewFailedCount: 1,
+        notificationEnabled: true,
+      })
+    )
+    expect(transport.trackListingFailed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        batchId: 'batch-preview',
+        failureStage: 'preview',
+        listingUrl: `${firstUrl}&copy=2`,
+      })
+    )
+  })
+
+  it('tracks save batches by original preview batch', () => {
+    const transport = createTransport()
+    const tracker = createWorkflowAnalytics({
+      createBatchId: () => 'batch-save',
+      getFilesystemSupported: () => true,
+      getNotificationEnabled: () => false,
+      now: () => 200,
+      transport,
+    })
+    const batch = tracker.previewStarted({ urlCount: 1, startedAt: 100 })
+
+    tracker.previewCompleted({
+      batch,
+      items: [{ id: 'listing-1', url: firstUrl, status: 'ready' }],
+    })
+    tracker.saveStarted({
+      items: [{ id: 'listing-1', url: firstUrl, listing }],
+      saveMethod: 'directory',
+    })
+    tracker.saveListingFailed({
+      item: { id: 'listing-1', url: firstUrl, listing },
+      message: '저장하지 못했어요.',
+    })
+    tracker.saveSettled({
+      items: [{ id: 'listing-1', url: firstUrl, listing }],
+      saveMethod: 'directory',
+      savedItemIds: new Set(),
+    })
+
+    expect(transport.trackSaveStarted).toHaveBeenCalledWith(
+      expect.objectContaining({
+        batchId: 'batch-save',
+        readyCount: 1,
+        saveMethod: 'directory',
+      })
+    )
+    expect(transport.trackListingFailed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        batchId: 'batch-save',
+        failureStage: 'save',
+        listingUrl: firstUrl,
+        vehicleNumber: '서울12가3456',
+        vehicleName: '현대 메가트럭',
+        imageCount: 1,
+      })
+    )
+    expect(transport.trackSaveFailed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        batchId: 'batch-save',
+        savedCount: 0,
+        saveFailedCount: 1,
+      })
+    )
+  })
+
+  it('removes listing analytics state when a chip is removed', () => {
+    const transport = createTransport()
+    const tracker = createWorkflowAnalytics({
+      createBatchId: () => 'batch-removed',
+      getFilesystemSupported: () => false,
+      getNotificationEnabled: () => false,
+      now: () => 300,
+      transport,
+    })
+    const batch = tracker.previewStarted({ urlCount: 1, startedAt: 250 })
+
+    tracker.previewCompleted({
+      batch,
+      items: [{ id: 'listing-1', url: firstUrl, status: 'ready' }],
+    })
+    tracker.removeListing('listing-1')
+    tracker.saveStarted({
+      items: [{ id: 'listing-1', url: firstUrl, listing }],
+      saveMethod: 'zip',
+    })
+
+    expect(transport.trackSaveStarted).toHaveBeenCalledWith(
+      expect.objectContaining({
+        batchId: expect.stringMatching(/^batch-/),
+        saveMethod: 'zip',
+      })
+    )
+  })
+})

--- a/src/v2/application/truck-harvester-workflow/workflow-analytics.test.ts
+++ b/src/v2/application/truck-harvester-workflow/workflow-analytics.test.ts
@@ -6,6 +6,8 @@ import { createWorkflowAnalytics } from './workflow-analytics'
 
 const firstUrl =
   'https://www.truck-no1.co.kr/model/DetailView.asp?ShopNo=1&MemberNo=2&OnCarNo=3'
+const secondUrl = `${firstUrl}&copy=2`
+const thirdUrl = `${firstUrl}&copy=3`
 
 const listing: TruckListing = {
   url: firstUrl,
@@ -58,17 +60,17 @@ describe('workflow analytics adapter', () => {
     expect(transport.trackBatchStarted).not.toHaveBeenCalled()
   })
 
-  it('tracks preview start and completion using aggregate counts only', () => {
+  it('tracks preview start and completion using aggregate counts and failure stages', () => {
     const transport = createTransport()
     const tracker = createWorkflowAnalytics({
       createBatchId: () => 'batch-preview',
-      getFilesystemSupported: () => true,
+      getFilesystemSupported: () => false,
       getNotificationEnabled: () => true,
       now: () => 100,
       transport,
     })
 
-    const batch = tracker.previewStarted({ urlCount: 2, startedAt: 25 })
+    const batch = tracker.previewStarted({ urlCount: 3, startedAt: 25 })
 
     tracker.previewCompleted({
       batch,
@@ -76,9 +78,15 @@ describe('workflow analytics adapter', () => {
         { id: 'listing-1', url: firstUrl, status: 'ready' },
         {
           id: 'listing-2',
-          url: `${firstUrl}&copy=2`,
+          url: secondUrl,
           status: 'failed',
           message: '매물 이름을 확인하지 못했어요.',
+        },
+        {
+          id: 'listing-3',
+          url: thirdUrl,
+          status: 'invalid',
+          message: '지원하지 않는 주소예요.',
         },
       ],
     })
@@ -86,18 +94,22 @@ describe('workflow analytics adapter', () => {
     expect(transport.trackBatchStarted).toHaveBeenCalledWith(
       expect.objectContaining({
         batchId: 'batch-preview',
-        urlCount: 2,
-        uniqueUrlCount: 2,
+        urlCount: 3,
+        uniqueUrlCount: 3,
         readyCount: 0,
+        filesystemSupported: false,
+        notificationEnabled: true,
       })
     )
     expect(transport.trackPreviewCompleted).toHaveBeenCalledWith(
       expect.objectContaining({
         batchId: 'batch-preview',
-        urlCount: 2,
-        uniqueUrlCount: 2,
+        urlCount: 3,
+        uniqueUrlCount: 3,
         readyCount: 1,
+        invalidCount: 1,
         previewFailedCount: 1,
+        filesystemSupported: false,
         notificationEnabled: true,
       })
     )
@@ -105,60 +117,113 @@ describe('workflow analytics adapter', () => {
       expect.objectContaining({
         batchId: 'batch-preview',
         failureStage: 'preview',
-        listingUrl: `${firstUrl}&copy=2`,
+        listingUrl: secondUrl,
+      })
+    )
+    expect(transport.trackListingFailed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        batchId: 'batch-preview',
+        failureStage: 'invalid_url',
+        listingUrl: thirdUrl,
       })
     )
   })
 
-  it('tracks save batches by original preview batch', () => {
+  it('tracks save batches separately by original preview batch', () => {
     const transport = createTransport()
     const tracker = createWorkflowAnalytics({
-      createBatchId: () => 'batch-save',
+      createBatchId: vi
+        .fn()
+        .mockReturnValueOnce('batch-save-first')
+        .mockReturnValueOnce('batch-save-second'),
       getFilesystemSupported: () => true,
       getNotificationEnabled: () => false,
       now: () => 200,
       transport,
     })
-    const batch = tracker.previewStarted({ urlCount: 1, startedAt: 100 })
+    const firstBatch = tracker.previewStarted({ urlCount: 1, startedAt: 100 })
+    const secondBatch = tracker.previewStarted({
+      urlCount: 1,
+      startedAt: 125,
+    })
 
     tracker.previewCompleted({
-      batch,
+      batch: firstBatch,
       items: [{ id: 'listing-1', url: firstUrl, status: 'ready' }],
     })
+    tracker.previewCompleted({
+      batch: secondBatch,
+      items: [{ id: 'listing-2', url: secondUrl, status: 'ready' }],
+    })
     tracker.saveStarted({
-      items: [{ id: 'listing-1', url: firstUrl, listing }],
+      items: [
+        { id: 'listing-1', url: firstUrl, listing },
+        {
+          id: 'listing-2',
+          url: secondUrl,
+          listing: { ...listing, url: secondUrl, vnumber: '부산34나7890' },
+        },
+      ],
       saveMethod: 'directory',
     })
     tracker.saveListingFailed({
-      item: { id: 'listing-1', url: firstUrl, listing },
+      item: {
+        id: 'listing-2',
+        url: secondUrl,
+        listing: { ...listing, url: secondUrl, vnumber: '부산34나7890' },
+      },
       message: '저장하지 못했어요.',
     })
     tracker.saveSettled({
-      items: [{ id: 'listing-1', url: firstUrl, listing }],
+      items: [
+        { id: 'listing-1', url: firstUrl, listing },
+        {
+          id: 'listing-2',
+          url: secondUrl,
+          listing: { ...listing, url: secondUrl, vnumber: '부산34나7890' },
+        },
+      ],
       saveMethod: 'directory',
-      savedItemIds: new Set(),
+      savedItemIds: new Set(['listing-1']),
     })
 
-    expect(transport.trackSaveStarted).toHaveBeenCalledWith(
+    expect(transport.trackSaveStarted).toHaveBeenCalledTimes(2)
+    expect(transport.trackSaveStarted).toHaveBeenNthCalledWith(
+      1,
       expect.objectContaining({
-        batchId: 'batch-save',
+        batchId: 'batch-save-first',
+        readyCount: 1,
+        saveMethod: 'directory',
+      })
+    )
+    expect(transport.trackSaveStarted).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        batchId: 'batch-save-second',
         readyCount: 1,
         saveMethod: 'directory',
       })
     )
     expect(transport.trackListingFailed).toHaveBeenCalledWith(
       expect.objectContaining({
-        batchId: 'batch-save',
+        batchId: 'batch-save-second',
         failureStage: 'save',
-        listingUrl: firstUrl,
-        vehicleNumber: '서울12가3456',
+        listingUrl: secondUrl,
+        vehicleNumber: '부산34나7890',
         vehicleName: '현대 메가트럭',
         imageCount: 1,
       })
     )
+    expect(transport.trackSaveCompleted).toHaveBeenCalledWith(
+      expect.objectContaining({
+        batchId: 'batch-save-first',
+        savedCount: 1,
+        saveFailedCount: 0,
+      })
+    )
     expect(transport.trackSaveFailed).toHaveBeenCalledWith(
       expect.objectContaining({
-        batchId: 'batch-save',
+        batchId: 'batch-save-second',
         savedCount: 0,
         saveFailedCount: 1,
       })
@@ -167,8 +232,12 @@ describe('workflow analytics adapter', () => {
 
   it('removes listing analytics state when a chip is removed', () => {
     const transport = createTransport()
+    const createBatchId = vi
+      .fn()
+      .mockReturnValueOnce('batch-original')
+      .mockReturnValueOnce('batch-fallback')
     const tracker = createWorkflowAnalytics({
-      createBatchId: () => 'batch-removed',
+      createBatchId,
       getFilesystemSupported: () => false,
       getNotificationEnabled: () => false,
       now: () => 300,
@@ -188,9 +257,11 @@ describe('workflow analytics adapter', () => {
 
     expect(transport.trackSaveStarted).toHaveBeenCalledWith(
       expect.objectContaining({
-        batchId: expect.stringMatching(/^batch-/),
+        batchId: 'batch-fallback',
         saveMethod: 'zip',
       })
     )
+    expect(batch.id).toBe('batch-original')
+    expect(createBatchId).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/v2/application/truck-harvester-workflow/workflow-analytics.test.ts
+++ b/src/v2/application/truck-harvester-workflow/workflow-analytics.test.ts
@@ -230,6 +230,62 @@ describe('workflow analytics adapter', () => {
     )
   })
 
+  it('clears previous save failures when the same listing is retried successfully', () => {
+    const transport = createTransport()
+    const tracker = createWorkflowAnalytics({
+      createBatchId: () => 'batch-retry-save',
+      getFilesystemSupported: () => true,
+      getNotificationEnabled: () => false,
+      now: () => 250,
+      transport,
+    })
+    const batch = tracker.previewStarted({ urlCount: 1, startedAt: 100 })
+    const item = { id: 'listing-1', url: firstUrl, listing }
+
+    tracker.previewCompleted({
+      batch,
+      items: [{ id: item.id, url: item.url, status: 'ready' }],
+    })
+    tracker.saveStarted({
+      items: [item],
+      saveMethod: 'directory',
+    })
+    tracker.saveListingFailed({
+      item,
+      message: '저장하지 못했어요.',
+    })
+    tracker.saveSettled({
+      items: [item],
+      saveMethod: 'directory',
+      savedItemIds: new Set(),
+    })
+
+    tracker.saveStarted({
+      items: [item],
+      saveMethod: 'directory',
+    })
+    tracker.saveSettled({
+      items: [item],
+      saveMethod: 'directory',
+      savedItemIds: new Set([item.id]),
+    })
+
+    expect(transport.trackSaveFailed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        batchId: 'batch-retry-save',
+        savedCount: 0,
+        saveFailedCount: 1,
+      })
+    )
+    expect(transport.trackSaveCompleted).toHaveBeenCalledWith(
+      expect.objectContaining({
+        batchId: 'batch-retry-save',
+        savedCount: 1,
+        saveFailedCount: 0,
+      })
+    )
+  })
+
   it('removes listing analytics state when a chip is removed', () => {
     const transport = createTransport()
     const createBatchId = vi

--- a/src/v2/application/truck-harvester-workflow/workflow-analytics.ts
+++ b/src/v2/application/truck-harvester-workflow/workflow-analytics.ts
@@ -248,6 +248,10 @@ export function createWorkflowAnalytics({
       })
     },
     saveStarted: ({ items, saveMethod }) => {
+      items.forEach((item) => {
+        saveFailureIds.delete(item.id)
+      })
+
       getSaveGroups(items).forEach((group) => {
         transport.trackSaveStarted(
           toBatchInput(group.batch, toReadyPreviewItems(group.items), {

--- a/src/v2/application/truck-harvester-workflow/workflow-analytics.ts
+++ b/src/v2/application/truck-harvester-workflow/workflow-analytics.ts
@@ -1,0 +1,303 @@
+import { type TruckListing } from '@/v2/entities/truck'
+import {
+  createAnalyticsBatchId,
+  trackBatchStarted,
+  trackListingFailed,
+  trackPreviewCompleted,
+  trackSaveCompleted,
+  trackSaveFailed,
+  trackSaveStarted,
+  trackUnsupportedInputFailure,
+  type BatchAnalyticsInput,
+  type SaveMethod,
+} from '@/v2/shared/lib/analytics'
+
+export interface AnalyticsBatchRef {
+  id: string
+  startedAt: number
+  urlCount: number
+}
+
+export type WorkflowPreviewItem =
+  | { id: string; url: string; status: 'ready' }
+  | { id: string; url: string; status: 'failed' | 'invalid'; message: string }
+
+export interface WorkflowSaveItem {
+  id: string
+  url: string
+  listing: TruckListing
+}
+
+export interface WorkflowAnalyticsTransport {
+  trackBatchStarted: typeof trackBatchStarted
+  trackListingFailed: typeof trackListingFailed
+  trackPreviewCompleted: typeof trackPreviewCompleted
+  trackSaveCompleted: typeof trackSaveCompleted
+  trackSaveFailed: typeof trackSaveFailed
+  trackSaveStarted: typeof trackSaveStarted
+  trackUnsupportedInputFailure: typeof trackUnsupportedInputFailure
+}
+
+export interface WorkflowTracker {
+  unsupportedInputFailed: (event: {
+    rawInput: string
+    startedAt: number
+  }) => void
+  previewStarted: (event: {
+    urlCount: number
+    startedAt: number
+  }) => AnalyticsBatchRef
+  previewCompleted: (event: {
+    batch: AnalyticsBatchRef
+    items: readonly WorkflowPreviewItem[]
+  }) => void
+  saveStarted: (event: {
+    items: readonly WorkflowSaveItem[]
+    saveMethod: SaveMethod
+  }) => void
+  saveListingFailed: (event: {
+    item: WorkflowSaveItem
+    message: string
+  }) => void
+  saveSettled: (event: {
+    items: readonly WorkflowSaveItem[]
+    saveMethod: SaveMethod
+    savedItemIds: ReadonlySet<string>
+  }) => void
+  removeListing: (id: string) => void
+}
+
+interface CreateWorkflowAnalyticsInput {
+  createBatchId?: () => string
+  getFilesystemSupported: () => boolean
+  getNotificationEnabled: () => boolean
+  now?: () => number
+  transport?: WorkflowAnalyticsTransport
+}
+
+interface SaveBatchGroup {
+  batch: AnalyticsBatchRef
+  items: WorkflowSaveItem[]
+}
+
+const missingListingIdentityPlaceholder = '차명 정보 없음'
+
+const defaultTransport: WorkflowAnalyticsTransport = {
+  trackBatchStarted,
+  trackListingFailed,
+  trackPreviewCompleted,
+  trackSaveCompleted,
+  trackSaveFailed,
+  trackSaveStarted,
+  trackUnsupportedInputFailure,
+}
+
+const getDuration = (now: () => number, startedAt: number) =>
+  Math.max(0, Math.round(now() - startedAt))
+
+const isUsableListingIdentity = (value: string) => {
+  const trimmedValue = value.trim()
+
+  return (
+    trimmedValue.length > 0 &&
+    trimmedValue !== missingListingIdentityPlaceholder
+  )
+}
+
+const getSaveFailureVehicleName = (listing: TruckListing) =>
+  [listing.vname, listing.vehicleName].find(isUsableListingIdentity) ||
+  listing.vname ||
+  listing.vehicleName
+
+export function createWorkflowAnalytics({
+  createBatchId = createAnalyticsBatchId,
+  getFilesystemSupported,
+  getNotificationEnabled,
+  now = () =>
+    typeof performance !== 'undefined' ? performance.now() : Date.now(),
+  transport = defaultTransport,
+}: CreateWorkflowAnalyticsInput): WorkflowTracker {
+  const batchByListingId = new Map<string, AnalyticsBatchRef>()
+  const saveFailureIds = new Set<string>()
+
+  const createBatch = (
+    urlCount: number,
+    startedAt: number
+  ): AnalyticsBatchRef => ({
+    id: createBatchId(),
+    startedAt,
+    urlCount,
+  })
+
+  const toBatchInput = (
+    batch: AnalyticsBatchRef,
+    items: readonly WorkflowPreviewItem[],
+    options: {
+      saveMethod?: SaveMethod
+      savedCount?: number
+      saveFailedCount?: number
+      uniqueUrlCount?: number
+    } = {}
+  ): BatchAnalyticsInput => ({
+    batchId: batch.id,
+    urlCount: batch.urlCount,
+    uniqueUrlCount: options.uniqueUrlCount ?? items.length,
+    readyCount: items.filter((item) => item.status === 'ready').length,
+    invalidCount: items.filter((item) => item.status === 'invalid').length,
+    previewFailedCount: items.filter((item) => item.status === 'failed').length,
+    savedCount: options.savedCount ?? 0,
+    saveFailedCount: options.saveFailedCount ?? 0,
+    durationMs: getDuration(now, batch.startedAt),
+    saveMethod: options.saveMethod,
+    filesystemSupported: getFilesystemSupported(),
+    notificationEnabled: getNotificationEnabled(),
+  })
+
+  const toReadyPreviewItems = (
+    items: readonly WorkflowSaveItem[]
+  ): WorkflowPreviewItem[] =>
+    items.map((item) => ({ id: item.id, url: item.url, status: 'ready' }))
+
+  const ensureFallbackBatch = (items: readonly WorkflowSaveItem[]) => {
+    const missingItems = items.filter((item) => !batchByListingId.has(item.id))
+
+    if (missingItems.length === 0) {
+      return
+    }
+
+    const fallbackBatch = createBatch(missingItems.length, now())
+
+    missingItems.forEach((item) => {
+      batchByListingId.set(item.id, fallbackBatch)
+    })
+  }
+
+  const getSaveGroups = (items: readonly WorkflowSaveItem[]) => {
+    ensureFallbackBatch(items)
+
+    const groups: SaveBatchGroup[] = []
+    const groupByBatchId = new Map<string, SaveBatchGroup>()
+
+    items.forEach((item) => {
+      const batch = batchByListingId.get(item.id)
+
+      if (!batch) {
+        return
+      }
+
+      const currentGroup = groupByBatchId.get(batch.id)
+
+      if (currentGroup) {
+        currentGroup.items.push(item)
+        return
+      }
+
+      const nextGroup = { batch, items: [item] }
+      groupByBatchId.set(batch.id, nextGroup)
+      groups.push(nextGroup)
+    })
+
+    return groups
+  }
+
+  const getSaveCounts = (
+    group: SaveBatchGroup,
+    savedItemIds: ReadonlySet<string>
+  ) => ({
+    savedCount: group.items.filter((item) => savedItemIds.has(item.id)).length,
+    saveFailedCount: group.items.filter((item) => saveFailureIds.has(item.id))
+      .length,
+  })
+
+  return {
+    unsupportedInputFailed: ({ rawInput, startedAt }) => {
+      transport.trackUnsupportedInputFailure({
+        batchId: createBatchId(),
+        rawInput,
+        elapsedMs: getDuration(now, startedAt),
+      })
+    },
+    previewStarted: ({ urlCount, startedAt }) => {
+      const batch = createBatch(urlCount, startedAt)
+
+      transport.trackBatchStarted(
+        toBatchInput(batch, [], { uniqueUrlCount: urlCount })
+      )
+
+      return batch
+    },
+    previewCompleted: ({ batch, items }) => {
+      items.forEach((item) => {
+        batchByListingId.set(item.id, batch)
+      })
+
+      transport.trackPreviewCompleted(toBatchInput(batch, items))
+
+      items.forEach((item) => {
+        if (item.status === 'ready') {
+          return
+        }
+
+        transport.trackListingFailed({
+          batchId: batch.id,
+          failureStage: item.status === 'invalid' ? 'invalid_url' : 'preview',
+          failureReason: item.message,
+          listingUrl: item.url,
+          elapsedMs: getDuration(now, batch.startedAt),
+        })
+      })
+    },
+    saveStarted: ({ items, saveMethod }) => {
+      getSaveGroups(items).forEach((group) => {
+        transport.trackSaveStarted(
+          toBatchInput(group.batch, toReadyPreviewItems(group.items), {
+            saveMethod,
+          })
+        )
+      })
+    },
+    saveListingFailed: ({ item, message }) => {
+      const batch = batchByListingId.get(item.id)
+
+      if (!batch) {
+        return
+      }
+
+      saveFailureIds.add(item.id)
+      transport.trackListingFailed({
+        batchId: batch.id,
+        failureStage: 'save',
+        failureReason: message,
+        listingUrl: item.url,
+        vehicleNumber: item.listing.vnumber,
+        vehicleName: getSaveFailureVehicleName(item.listing),
+        imageCount: item.listing.images.length,
+        elapsedMs: getDuration(now, batch.startedAt),
+      })
+    },
+    saveSettled: ({ items, saveMethod, savedItemIds }) => {
+      getSaveGroups(items).forEach((group) => {
+        const counts = getSaveCounts(group, savedItemIds)
+        const input = toBatchInput(
+          group.batch,
+          toReadyPreviewItems(group.items),
+          {
+            ...counts,
+            saveMethod,
+          }
+        )
+
+        if (counts.savedCount === group.items.length) {
+          transport.trackSaveCompleted(input)
+          return
+        }
+
+        transport.trackSaveFailed(input)
+      })
+    },
+    removeListing: (id) => {
+      batchByListingId.delete(id)
+      saveFailureIds.delete(id)
+    },
+  }
+}

--- a/src/v2/features/listing-preparation/index.ts
+++ b/src/v2/features/listing-preparation/index.ts
@@ -1,5 +1,14 @@
 export {
   prepareListingUrls,
+  type PreparedListingRunItem,
+  type PreparedListingSettledItem,
   type PrepareListingUrlsInput,
 } from './model/prepare-listings'
 export * from './model/prepared-listing-store'
+export {
+  extractTruckUrlsFromText,
+  parseUrlInputText,
+  type UrlInputFailure,
+  type UrlInputResult,
+  type UrlInputSuccess,
+} from './model/url-input-parser'

--- a/src/v2/features/listing-preparation/model/__tests__/url-input-parser.test.ts
+++ b/src/v2/features/listing-preparation/model/__tests__/url-input-parser.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  extractTruckUrlsFromText,
+  parseUrlInputText,
+} from '../url-input-parser'
+
+const validUrl =
+  'https://www.truck-no1.co.kr/model/DetailView.asp?ShopNo=1&MemberNo=2&OnCarNo=3'
+
+describe('listing preparation url input parser', () => {
+  it('extracts supported truck listing addresses from pasted prose', () => {
+    expect(
+      extractTruckUrlsFromText(`확인 부탁드립니다\n${validUrl})\n감사합니다`)
+    ).toEqual([validUrl])
+  })
+
+  it('deduplicates normalized listing addresses', () => {
+    expect(extractTruckUrlsFromText(`${validUrl}\n${validUrl}.`)).toEqual([
+      validUrl,
+    ])
+  })
+
+  it('returns Korean empty-input guidance for whitespace', () => {
+    expect(parseUrlInputText(' \n\t ')).toEqual({
+      success: false,
+      message: '매물 주소를 찾지 못했어요. 복사한 내용을 다시 확인해 주세요.',
+    })
+  })
+
+  it('returns Korean invalid-input guidance when no supported address exists', () => {
+    expect(parseUrlInputText('DetailView.asp?ShopNo=1')).toEqual({
+      success: false,
+      message: '매물 주소를 찾지 못했어요. 복사한 내용을 다시 확인해 주세요.',
+    })
+  })
+
+  it('returns supported listing addresses for valid pasted input', () => {
+    expect(parseUrlInputText(`메모\n${validUrl}`)).toEqual({
+      success: true,
+      urls: [validUrl],
+    })
+  })
+})

--- a/src/v2/features/listing-preparation/model/url-input-parser.ts
+++ b/src/v2/features/listing-preparation/model/url-input-parser.ts
@@ -1,0 +1,59 @@
+import { normalizeTruckUrl } from '@/v2/entities/url'
+import { v2Copy } from '@/v2/shared/lib/copy'
+
+export interface UrlInputSuccess {
+  success: true
+  urls: string[]
+}
+
+export interface UrlInputFailure {
+  success: false
+  message: string
+}
+
+export type UrlInputResult = UrlInputSuccess | UrlInputFailure
+
+const supportedTruckUrlPattern =
+  /https?:\/\/www\.truck-no1\.co\.kr\/model\/DetailView\.asp\?[A-Za-z0-9\-._~:/?#[\]@!$&'()*+,;=%]+/gi
+const trailingChatPunctuationPattern = /[.,)\]}]+$/g
+
+const stripTrailingChatPunctuation = (value: string) =>
+  value.replace(trailingChatPunctuationPattern, '')
+
+export function extractTruckUrlsFromText(value: string): string[] {
+  const normalizedUrls = new Set<string>()
+  const matches = value.match(supportedTruckUrlPattern) ?? []
+
+  for (const match of matches) {
+    try {
+      normalizedUrls.add(normalizeTruckUrl(stripTrailingChatPunctuation(match)))
+    } catch {
+      continue
+    }
+  }
+
+  return Array.from(normalizedUrls)
+}
+
+export function parseUrlInputText(value: string): UrlInputResult {
+  if (value.trim().length === 0) {
+    return {
+      success: false,
+      message: v2Copy.urlInput.errors.empty,
+    }
+  }
+
+  const urls = extractTruckUrlsFromText(value)
+
+  if (urls.length === 0) {
+    return {
+      success: false,
+      message: v2Copy.urlInput.errors.invalid,
+    }
+  }
+
+  return {
+    success: true,
+    urls,
+  }
+}

--- a/src/v2/testing/__tests__/knowledge-base.test.ts
+++ b/src/v2/testing/__tests__/knowledge-base.test.ts
@@ -21,6 +21,7 @@ const requiredDocs = [
 const layerAgentFiles = [
   'AGENTS.md',
   'src/v2/AGENTS.md',
+  'src/v2/application/AGENTS.md',
   'src/v2/entities/AGENTS.md',
   'src/v2/features/AGENTS.md',
   'src/v2/shared/AGENTS.md',
@@ -54,6 +55,16 @@ describe('v2 AI knowledge base', () => {
     })
 
     expect(missingLinks).toEqual([])
+  })
+
+  it('documents the application workflow layer', () => {
+    const guide = readText('src/v2/AGENTS.md')
+    const applicationGuide = readText('src/v2/application/AGENTS.md')
+
+    expect(guide).toContain('application/')
+    expect(applicationGuide).toContain('business workflow orchestration')
+    expect(applicationGuide).toContain('must not import widgets')
+    expect(applicationGuide).toContain('workflow analytics')
   })
 
   it('documents the v2 data flow with a Mermaid diagram', () => {

--- a/src/v2/widgets/url-input/model/url-input-schema.ts
+++ b/src/v2/widgets/url-input/model/url-input-schema.ts
@@ -1,59 +1,9 @@
-import { normalizeTruckUrl } from '@/v2/entities/url'
-import { v2Copy } from '@/v2/shared/lib/copy'
-
-export interface UrlInputSuccess {
-  success: true
-  urls: string[]
-}
-
-export interface UrlInputFailure {
-  success: false
-  message: string
-}
-
-export type UrlInputResult = UrlInputSuccess | UrlInputFailure
-
-const supportedTruckUrlPattern =
-  /https?:\/\/www\.truck-no1\.co\.kr\/model\/DetailView\.asp\?[A-Za-z0-9\-._~:/?#[\]@!$&'()*+,;=%]+/gi
-const trailingChatPunctuationPattern = /[.,)\]}]+$/g
-
-const stripTrailingChatPunctuation = (value: string) =>
-  value.replace(trailingChatPunctuationPattern, '')
-
-export function extractTruckUrlsFromText(value: string): string[] {
-  const normalizedUrls = new Set<string>()
-  const matches = value.match(supportedTruckUrlPattern) ?? []
-
-  for (const match of matches) {
-    try {
-      normalizedUrls.add(normalizeTruckUrl(stripTrailingChatPunctuation(match)))
-    } catch {
-      continue
-    }
-  }
-
-  return Array.from(normalizedUrls)
-}
-
-export function parseUrlInputText(value: string): UrlInputResult {
-  if (value.trim().length === 0) {
-    return {
-      success: false,
-      message: v2Copy.urlInput.errors.empty,
-    }
-  }
-
-  const urls = extractTruckUrlsFromText(value)
-
-  if (urls.length === 0) {
-    return {
-      success: false,
-      message: v2Copy.urlInput.errors.invalid,
-    }
-  }
-
-  return {
-    success: true,
-    urls,
-  }
-}
+export {
+  extractTruckUrlsFromText,
+  parseUrlInputText,
+} from '@/v2/features/listing-preparation/model/url-input-parser'
+export type {
+  UrlInputFailure,
+  UrlInputResult,
+  UrlInputSuccess,
+} from '@/v2/features/listing-preparation/model/url-input-parser'


### PR DESCRIPTION
## Summary
- Move pasted URL parsing into the listing-preparation feature layer while preserving widget compatibility.
- Add an application workflow layer for preview/save orchestration and isolate Umami payload conversion in `workflow-analytics.ts`.
- Slim the root Truck Harvester app to UI composition and update architecture/spec docs for the new boundary.

## Test Plan
- [x] `bun run test -- --run src/v2/application/truck-harvester-workflow src/v2/features/listing-preparation/model/__tests__/url-input-parser.test.ts src/v2/widgets/url-input/model/__tests__/url-input-schema.test.ts src/app/__tests__/truck-harvester-app.test.tsx`
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test -- --run`
- [x] `bun run format:check`
- [x] `bun run test:coverage -- --run` (statements 89.65%, branches 78.55%, functions 91.23%, lines 89.49%)
- [x] `bun run build` (passed after rerun outside sandbox; initial sandbox run hit Turbopack port-binding permission error)

## Review / Security Evidence
- Final implementation review approved with no blocking findings.
- Route/widgets no longer assemble Umami payloads; preview/save use cases emit business facts through `WorkflowTracker`.
- No external error-monitoring SDK or new analytics provider added.
- Commit new-file rule checked: max 2 newly added files per commit.