### PR TITLE
[codex] duration bucket analytics review fix

### DIFF
--- a/docs/superpowers/plans/2026-04-30-duration-bucket-analytics-review-fix.md
+++ b/docs/superpowers/plans/2026-04-30-duration-bucket-analytics-review-fix.md
@@ -1,0 +1,417 @@
+# Duration Bucket Analytics Review Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep `duration_bucket` scoped to `save_completed` and make `duration_ms` use the same normalized duration value as the bucket.
+
+**Architecture:** `toBatchEventData()` remains the shared aggregate batch payload builder and stops emitting `duration_bucket`. `trackSaveCompleted()` becomes the only save-completed-specific analytics path that adds the derived bucket. A private `normalizeDurationMs()` helper guards the analytics transport boundary so every batch event emits a finite, non-negative integer `duration_ms`.
+
+**Tech Stack:** TypeScript, Vitest, Umami browser tracker wrapper, Next.js app code under `src/v2/shared/lib`.
+
+---
+
+## Scope Check
+
+This plan covers one focused analytics transport correction. It does not add new
+events, dashboards, user identifiers, app UI, or workflow-level tracking logic.
+
+## File Structure
+
+- Modify `src/v2/shared/lib/analytics.ts`
+  - Add private `normalizeDurationMs(durationMs: number)` near the analytics
+    helper constants.
+  - Update `toDurationBucket()` to derive buckets from `normalizeDurationMs()`.
+  - Update `toBatchEventData()` to emit normalized `duration_ms` and stop
+    emitting `duration_bucket`.
+  - Update `trackSaveCompleted()` to add `duration_bucket` to the
+    save-completed payload only.
+- Modify `src/v2/shared/lib/__tests__/analytics.test.ts`
+  - Update the aggregate batch payload expectation so `duration_bucket` is
+    absent from the shared builder.
+  - Add duration normalization tests for `toBatchEventData()`.
+  - Add a non-save batch event tracking assertion that verifies
+    `duration_bucket` is not sent.
+  - Update the save-completed tracking assertion to verify normalized
+    `duration_ms` and `duration_bucket` are sent together.
+
+## Task 1: Lock The Analytics Payload Contract With Failing Tests
+
+**Files:**
+
+- Modify: `src/v2/shared/lib/__tests__/analytics.test.ts`
+
+- [ ] **Step 1: Update the analytics import block**
+
+In `src/v2/shared/lib/__tests__/analytics.test.ts`, keep the existing import list
+and make sure `trackBatchStarted` and `trackSaveCompleted` are imported:
+
+```ts
+import {
+  createAnalyticsBatchId,
+  toBatchEventData,
+  toDurationBucket,
+  toListingFailureEventData,
+  toUnsupportedInputFailureInput,
+  trackBatchStarted,
+  trackListingFailed,
+  trackSaveCompleted,
+  trackUnsupportedInputFailure,
+} from '../analytics'
+```
+
+Expected: this is already true in the current file, so this step is a quick
+confirmation before editing assertions.
+
+- [ ] **Step 2: Change the shared batch payload expectation**
+
+In the `builds batch event data with aggregate fields only` test, remove
+`duration_bucket` from the expected object and add an explicit absence assertion:
+
+```ts
+expect(data).toEqual({
+  batch_id: 'batch-1',
+  url_count: 3,
+  unique_url_count: 2,
+  ready_count: 1,
+  invalid_count: 1,
+  preview_failed_count: 0,
+  saved_count: 1,
+  save_failed_count: 0,
+  duration_ms: 1234,
+  save_method: 'directory',
+  filesystem_supported: true,
+  notification_enabled: false,
+})
+expect(data).not.toHaveProperty('duration_bucket')
+expect(data).not.toHaveProperty('listing_url')
+expect(data).not.toHaveProperty('vehicle_number')
+expect(data).not.toHaveProperty('vehicle_name')
+```
+
+- [ ] **Step 3: Add duration normalization tests for the shared builder**
+
+Still inside `describe('analytics payload builders', () => { ... })`, add this
+test immediately after `builds batch event data with aggregate fields only`:
+
+```ts
+it.each([
+  [Number.NaN, 0],
+  [Number.POSITIVE_INFINITY, 0],
+  [Number.NEGATIVE_INFINITY, 0],
+  [-1, 0],
+  [0, 0],
+  [999.9, 999],
+  [1000.7, 1000],
+])('normalizes %s ms to duration_ms %s', (durationMs, expectedDurationMs) => {
+  const data = toBatchEventData({
+    batchId: 'batch-normalized',
+    urlCount: 1,
+    uniqueUrlCount: 1,
+    readyCount: 1,
+    invalidCount: 0,
+    previewFailedCount: 0,
+    savedCount: 1,
+    saveFailedCount: 0,
+    durationMs,
+    filesystemSupported: true,
+    notificationEnabled: false,
+  })
+
+  expect(data).toMatchObject({
+    duration_ms: expectedDurationMs,
+  })
+})
+```
+
+- [ ] **Step 4: Add a non-save event assertion**
+
+Inside `describe('analytics tracking', () => { ... })`, add this test after
+`does nothing when the Umami tracker is missing`:
+
+```ts
+it('does not send duration bucket with batch_started event data', () => {
+  const track = vi.fn()
+  stubWindow({ umami: { track } })
+
+  trackBatchStarted({
+    batchId: 'batch-started',
+    urlCount: 2,
+    uniqueUrlCount: 2,
+    readyCount: 0,
+    invalidCount: 0,
+    previewFailedCount: 0,
+    savedCount: 0,
+    saveFailedCount: 0,
+    durationMs: Number.NaN,
+    filesystemSupported: true,
+    notificationEnabled: false,
+  })
+
+  expect(track).toHaveBeenCalledWith('batch_started', {
+    batch_id: 'batch-started',
+    url_count: 2,
+    unique_url_count: 2,
+    ready_count: 0,
+    invalid_count: 0,
+    preview_failed_count: 0,
+    saved_count: 0,
+    save_failed_count: 0,
+    duration_ms: 0,
+    filesystem_supported: true,
+    notification_enabled: false,
+  })
+})
+```
+
+- [ ] **Step 5: Update save-completed tracking to verify normalization**
+
+In the existing `sends duration bucket with save_completed event data` test,
+change `durationMs` from `6420` to `6420.9`, and change the expected
+`duration_ms` from `6420` to `6420` while keeping the same bucket:
+
+```ts
+trackSaveCompleted({
+  batchId: 'batch-1',
+  urlCount: 4,
+  uniqueUrlCount: 4,
+  readyCount: 4,
+  invalidCount: 0,
+  previewFailedCount: 0,
+  savedCount: 4,
+  saveFailedCount: 0,
+  durationMs: 6420.9,
+  saveMethod: 'directory',
+  filesystemSupported: true,
+  notificationEnabled: false,
+})
+
+expect(track).toHaveBeenCalledWith('save_completed', {
+  batch_id: 'batch-1',
+  url_count: 4,
+  unique_url_count: 4,
+  ready_count: 4,
+  invalid_count: 0,
+  preview_failed_count: 0,
+  saved_count: 4,
+  save_failed_count: 0,
+  duration_ms: 6420,
+  duration_bucket: '06_6s',
+  save_method: 'directory',
+  filesystem_supported: true,
+  notification_enabled: false,
+})
+```
+
+- [ ] **Step 6: Run the focused test and verify it fails**
+
+Run:
+
+```bash
+bun run test -- --run src/v2/shared/lib/__tests__/analytics.test.ts
+```
+
+Expected: FAIL. The shared builder still emits `duration_bucket`, `duration_ms`
+is not normalized in `toBatchEventData()`, and `batch_started` still includes a
+bucket.
+
+## Task 2: Implement Save-Completed-Only Bucket Emission
+
+**Files:**
+
+- Modify: `src/v2/shared/lib/analytics.ts`
+
+- [ ] **Step 1: Add the private duration normalizer**
+
+In `src/v2/shared/lib/analytics.ts`, add this helper after
+`compactEventData` and before `trackEvent`:
+
+```ts
+const normalizeDurationMs = (durationMs: number) => {
+  if (!Number.isFinite(durationMs)) {
+    return 0
+  }
+
+  return Math.max(0, Math.floor(durationMs))
+}
+```
+
+- [ ] **Step 2: Update `toDurationBucket()` to share the normalizer**
+
+Replace the first lines of `toDurationBucket()` with this implementation:
+
+```ts
+export function toDurationBucket(durationMs: number) {
+  const normalizedDurationMs = normalizeDurationMs(durationMs)
+
+  if (normalizedDurationMs < 1000) {
+    return '00_under_1s'
+  }
+
+  const seconds = Math.floor(normalizedDurationMs / 1000)
+
+  if (seconds >= 10) {
+    return '10_10s_plus'
+  }
+
+  const paddedSeconds = seconds.toString().padStart(2, '0')
+
+  return `${paddedSeconds}_${seconds}s`
+}
+```
+
+- [ ] **Step 3: Update the shared batch payload builder**
+
+Replace `toBatchEventData()` with this version:
+
+```ts
+export function toBatchEventData(input: BatchAnalyticsInput) {
+  const durationMs = normalizeDurationMs(input.durationMs)
+
+  return compactEventData({
+    batch_id: input.batchId,
+    url_count: input.urlCount,
+    unique_url_count: input.uniqueUrlCount,
+    ready_count: input.readyCount,
+    invalid_count: input.invalidCount,
+    preview_failed_count: input.previewFailedCount,
+    saved_count: input.savedCount,
+    save_failed_count: input.saveFailedCount,
+    duration_ms: durationMs,
+    save_method: input.saveMethod,
+    filesystem_supported: input.filesystemSupported,
+    notification_enabled: input.notificationEnabled,
+  })
+}
+```
+
+- [ ] **Step 4: Add the bucket only inside `trackSaveCompleted()`**
+
+Replace the current `trackSaveCompleted()` export with this version:
+
+```ts
+export const trackSaveCompleted = (input: BatchAnalyticsInput) => {
+  const durationMs = normalizeDurationMs(input.durationMs)
+
+  trackEvent('save_completed', {
+    ...toBatchEventData({
+      ...input,
+      durationMs,
+    }),
+    duration_bucket: toDurationBucket(durationMs),
+  })
+}
+```
+
+Expected: `trackSaveCompleted()` is now the only batch tracker that emits
+`duration_bucket`.
+
+- [ ] **Step 5: Run the focused test and verify it passes**
+
+Run:
+
+```bash
+bun run test -- --run src/v2/shared/lib/__tests__/analytics.test.ts
+```
+
+Expected: PASS. The analytics test file should report all tests passing.
+
+- [ ] **Step 6: Commit the implementation**
+
+Run:
+
+```bash
+git add src/v2/shared/lib/analytics.ts src/v2/shared/lib/__tests__/analytics.test.ts
+git commit -m "fix: duration bucket 전송 범위 보정"
+```
+
+Expected: one commit containing only the analytics implementation and tests.
+
+## Task 3: Final Verification
+
+**Files:**
+
+- Read: `docs/superpowers/specs/2026-04-30-duration-bucket-analytics-review-fix-design.md`
+- Read: `src/v2/shared/lib/analytics.ts`
+- Read: `src/v2/shared/lib/__tests__/analytics.test.ts`
+
+- [ ] **Step 1: Run the full finite test command**
+
+Run:
+
+```bash
+bun run test -- --run
+```
+
+Expected: PASS. Use `--run` so Vitest exits instead of entering watch mode.
+
+- [ ] **Step 2: Run typecheck**
+
+Run:
+
+```bash
+bun run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run lint**
+
+Run:
+
+```bash
+bun run lint
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run format check**
+
+Run:
+
+```bash
+bun run format:check
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Confirm the emitted payload shape manually**
+
+Check `src/v2/shared/lib/analytics.ts` and confirm:
+
+```ts
+export function toBatchEventData(input: BatchAnalyticsInput) {
+  const durationMs = normalizeDurationMs(input.durationMs)
+
+  return compactEventData({
+    duration_ms: durationMs,
+  })
+}
+```
+
+Also confirm `trackSaveCompleted()` is the only batch event wrapper that adds:
+
+```ts
+duration_bucket: toDurationBucket(durationMs),
+```
+
+- [ ] **Step 6: Confirm git status is clean**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: no output.
+
+## Self-Review Notes
+
+- Spec coverage: Task 1 locks the two review findings with failing tests. Task 2
+  scopes bucket emission to `save_completed` and shares one normalized duration
+  value. Task 3 verifies the whole repo-facing test/check surface.
+- Placeholder scan: The plan contains no placeholder or fill-in steps. Code
+  steps include concrete snippets and exact commands.
+- Type consistency: The plan uses the existing `BatchAnalyticsInput`,
+  `toBatchEventData()`, `toDurationBucket()`, `trackBatchStarted()`, and
+  `trackSaveCompleted()` names. The only new helper is private
+  `normalizeDurationMs()`.

--- a/docs/superpowers/specs/2026-04-30-duration-bucket-analytics-review-fix-design.md
+++ b/docs/superpowers/specs/2026-04-30-duration-bucket-analytics-review-fix-design.md
@@ -1,0 +1,102 @@
+# Duration Bucket Analytics Review Fix Design
+
+작성일: 2026-04-30
+
+## 배경
+
+최근 `duration_bucket` 분석 속성은 공용 배치 payload builder인
+`toBatchEventData()`에 추가되었다. 이 구조는 구현은 작지만
+`batch_started`, `preview_completed`, `save_started`, `save_failed`,
+`save_completed` 모두에 `duration_bucket`을 전송한다.
+
+체크인된 설계 문서의 분석 질문은 `save_completed` 기준 작업 완료 시간
+분포다. `batch_started`처럼 거의 항상 0초대인 이벤트가 같은 속성을 가지면
+Umami Properties 화면에서 이벤트를 잘못 선택했을 때 분석 의미가 흐려진다.
+
+또한 현재 `toDurationBucket()`은 `NaN`, `Infinity`, 음수를 0초대로
+보정하지만, 같은 payload의 `duration_ms`는 원본 `input.durationMs`를 그대로
+보낸다. 미래 caller가 비정상 값을 넘기면 `duration_ms`와
+`duration_bucket`이 서로 다른 기준의 값이 된다.
+
+## 목표
+
+- `duration_bucket`은 우선 `save_completed` 이벤트에만 전송한다.
+- `duration_ms`와 `duration_bucket`은 같은 정규화된 duration 값을 사용한다.
+- 기존 `duration_ms` 숫자 속성은 유지한다.
+- 성공 매물 식별 정보 비수집 원칙은 유지한다.
+- 앱 UI, 사용자 작업 흐름, Umami script 설정은 바꾸지 않는다.
+
+## 비목표
+
+- `preview_completed`나 `save_failed`에 duration bucket을 추가하지 않는다.
+- 평균, 중앙값, p95를 앱 UI에 표시하지 않는다.
+- 사용자 식별자를 추가하지 않는다.
+- Umami 대시보드나 export 파이프라인을 구현하지 않는다.
+
+## 확정 접근
+
+`duration_bucket`은 `trackSaveCompleted()`에서만 붙인다.
+`toBatchEventData()`는 공통 배치 이벤트 속성만 만든다.
+
+정규화는 작은 helper로 분리한다.
+
+```ts
+const normalizeDurationMs = (durationMs: number) => {
+  if (!Number.isFinite(durationMs)) {
+    return 0
+  }
+
+  return Math.max(0, Math.floor(durationMs))
+}
+```
+
+`Math.floor()`를 쓰는 이유는 기존 경계값 보정 의도를 유지하기 위해서다.
+`999.9ms`는 여전히 1초 미만이며, `1000ms`부터 `01_1s`가 된다. 현재
+workflow analytics는 이미 `Math.round(now() - startedAt)`으로 정수 duration을
+만들어 전달하므로, production path에서는 값 변화가 없다. 이 helper는
+analytics transport 경계에서 비정상 입력과 미래 직접 호출을 방어한다.
+
+## 데이터 흐름
+
+1. workflow layer는 기존처럼 `BatchAnalyticsInput.durationMs`를 전달한다.
+2. analytics transport는 `normalizeDurationMs(input.durationMs)`를 계산한다.
+3. 공통 배치 payload는 정규화된 `duration_ms`만 포함한다.
+4. `trackSaveCompleted()`는 공통 payload에
+   `duration_bucket: toDurationBucket(normalizedDurationMs)`를 추가한다.
+5. 다른 배치 이벤트는 `duration_ms`만 보내고 `duration_bucket`은 보내지 않는다.
+
+## API 경계
+
+- `toBatchEventData(input)`은 계속 export한다.
+- `toDurationBucket(durationMs)`은 계속 export한다.
+- `normalizeDurationMs()`는 내부 helper로 둔다. 외부 caller가 duration
+  정규화 정책에 의존하지 않게 analytics transport 내부에 가둔다.
+- `trackSaveCompleted(input)`은 내부에서 save-completed 전용 payload를 만든다.
+  별도 public builder를 추가하지 않는다.
+
+## 테스트 계획
+
+- `toDurationBucket()` 경계 테스트는 유지한다.
+  - `999.9`는 `00_under_1s`
+  - `1000`은 `01_1s`
+  - `9999.9`는 `09_9s`
+  - `10000`은 `10_10s_plus`
+- `toBatchEventData()` expectation에서 `duration_bucket`이 없음을 검증한다.
+- `toBatchEventData()`가 `NaN`, `Infinity`, 음수 duration을 `duration_ms: 0`으로
+  정규화하는 케이스를 추가한다.
+- `trackSaveCompleted()`가 정규화된 `duration_ms`와 `duration_bucket`을 함께
+  전송하는지 검증한다.
+- `trackBatchStarted()` 같은 다른 batch event가 `duration_bucket`을 보내지
+  않는지 최소 한 케이스로 검증한다.
+- 기존 fallback 동작은 유지한다. `window.umami`가 없거나 `track()`이 예외를
+  던져도 앱 작업은 실패하지 않는다.
+
+## 유지보수 기준
+
+나중에 `preview_completed`나 `save_failed`에도 bucket 분석이 필요하면
+`trackSaveCompleted()` 전용 분기를 복사하지 않는다. 그 시점에는 어떤 이벤트에
+bucket을 붙일지 명시한 작은 allowlist나 event-specific payload builder를
+도입하고, 설계 문서도 함께 갱신한다.
+
+이번 변경은 분석 의미를 좁히는 수정이다. 데이터 수집량을 늘리는 변경이
+아니므로 privacy boundary는 그대로 유지된다.

--- a/src/v2/shared/lib/__tests__/analytics.test.ts
+++ b/src/v2/shared/lib/__tests__/analytics.test.ts
@@ -83,14 +83,42 @@ describe('analytics payload builders', () => {
       saved_count: 1,
       save_failed_count: 0,
       duration_ms: 1234,
-      duration_bucket: '01_1s',
       save_method: 'directory',
       filesystem_supported: true,
       notification_enabled: false,
     })
+    expect(data).not.toHaveProperty('duration_bucket')
     expect(data).not.toHaveProperty('listing_url')
     expect(data).not.toHaveProperty('vehicle_number')
     expect(data).not.toHaveProperty('vehicle_name')
+  })
+
+  it.each([
+    [Number.NaN, 0],
+    [Number.POSITIVE_INFINITY, 0],
+    [Number.NEGATIVE_INFINITY, 0],
+    [-1, 0],
+    [0, 0],
+    [999.9, 999],
+    [1000.7, 1000],
+  ])('normalizes %s ms to duration_ms %s', (durationMs, expectedDurationMs) => {
+    const data = toBatchEventData({
+      batchId: 'batch-normalized',
+      urlCount: 1,
+      uniqueUrlCount: 1,
+      readyCount: 1,
+      invalidCount: 0,
+      previewFailedCount: 0,
+      savedCount: 1,
+      saveFailedCount: 0,
+      durationMs,
+      filesystemSupported: true,
+      notificationEnabled: false,
+    })
+
+    expect(data).toMatchObject({
+      duration_ms: expectedDurationMs,
+    })
   })
 
   it('omits optional failure fields when the listing was never parsed', () => {
@@ -209,6 +237,39 @@ describe('analytics tracking', () => {
     ).not.toThrow()
   })
 
+  it('does not send duration bucket with batch_started event data', () => {
+    const track = vi.fn()
+    stubWindow({ umami: { track } })
+
+    trackBatchStarted({
+      batchId: 'batch-started',
+      urlCount: 2,
+      uniqueUrlCount: 2,
+      readyCount: 0,
+      invalidCount: 0,
+      previewFailedCount: 0,
+      savedCount: 0,
+      saveFailedCount: 0,
+      durationMs: Number.NaN,
+      filesystemSupported: true,
+      notificationEnabled: false,
+    })
+
+    expect(track).toHaveBeenCalledWith('batch_started', {
+      batch_id: 'batch-started',
+      url_count: 2,
+      unique_url_count: 2,
+      ready_count: 0,
+      invalid_count: 0,
+      preview_failed_count: 0,
+      saved_count: 0,
+      save_failed_count: 0,
+      duration_ms: 0,
+      filesystem_supported: true,
+      notification_enabled: false,
+    })
+  })
+
   it('sends named events with event data to Umami', () => {
     const track = vi.fn()
     stubWindow({ umami: { track } })
@@ -245,7 +306,7 @@ describe('analytics tracking', () => {
       previewFailedCount: 0,
       savedCount: 4,
       saveFailedCount: 0,
-      durationMs: 6420,
+      durationMs: 6420.9,
       saveMethod: 'directory',
       filesystemSupported: true,
       notificationEnabled: false,

--- a/src/v2/shared/lib/analytics.ts
+++ b/src/v2/shared/lib/analytics.ts
@@ -59,6 +59,14 @@ const compactEventData = (data: OptionalAnalyticsEventData) =>
     Object.entries(data).filter(([, value]) => value !== undefined)
   ) as AnalyticsEventData
 
+const normalizeDurationMs = (durationMs: number) => {
+  if (!Number.isFinite(durationMs)) {
+    return 0
+  }
+
+  return Math.max(0, Math.floor(durationMs))
+}
+
 const trackEvent = (eventName: string, data: OptionalAnalyticsEventData) => {
   if (typeof window === 'undefined') {
     return
@@ -78,9 +86,7 @@ export function createAnalyticsBatchId() {
 }
 
 export function toDurationBucket(durationMs: number) {
-  const normalizedDurationMs = Number.isFinite(durationMs)
-    ? Math.max(0, durationMs)
-    : 0
+  const normalizedDurationMs = normalizeDurationMs(durationMs)
 
   if (normalizedDurationMs < 1000) {
     return '00_under_1s'
@@ -98,6 +104,8 @@ export function toDurationBucket(durationMs: number) {
 }
 
 export function toBatchEventData(input: BatchAnalyticsInput) {
+  const durationMs = normalizeDurationMs(input.durationMs)
+
   return compactEventData({
     batch_id: input.batchId,
     url_count: input.urlCount,
@@ -107,8 +115,7 @@ export function toBatchEventData(input: BatchAnalyticsInput) {
     preview_failed_count: input.previewFailedCount,
     saved_count: input.savedCount,
     save_failed_count: input.saveFailedCount,
-    duration_ms: input.durationMs,
-    duration_bucket: toDurationBucket(input.durationMs),
+    duration_ms: durationMs,
     save_method: input.saveMethod,
     filesystem_supported: input.filesystemSupported,
     notification_enabled: input.notificationEnabled,
@@ -163,7 +170,15 @@ export const trackSaveStarted = (input: BatchAnalyticsInput) => {
 }
 
 export const trackSaveCompleted = (input: BatchAnalyticsInput) => {
-  trackEvent('save_completed', toBatchEventData(input))
+  const durationMs = normalizeDurationMs(input.durationMs)
+
+  trackEvent('save_completed', {
+    ...toBatchEventData({
+      ...input,
+      durationMs,
+    }),
+    duration_bucket: toDurationBucket(durationMs),
+  })
 }
 
 export const trackSaveFailed = (input: BatchAnalyticsInput) => {


### PR DESCRIPTION
## Summary
- Scope `duration_bucket` emission to `save_completed` so non-save batch events keep only normalized `duration_ms`.
- Normalize duration values at the analytics transport boundary before emitting `duration_ms` or deriving buckets.
- Add review-fix design and implementation plan docs for the analytics payload contract.

## Why
The previous shared batch payload builder attached `duration_bucket` to every batch event and allowed raw invalid duration values to leak through `duration_ms`. That could confuse Umami property analysis and make `duration_ms` disagree with the derived bucket.

## Test Plan
- `bun run test -- --run`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`