### PR TITLE
성능점검 저장 analytics 집계

### DIFF
--- a/docs/superpowers/plans/2026-06-25-performance-check-analytics.md
+++ b/docs/superpowers/plans/2026-06-25-performance-check-analytics.md
@@ -1,0 +1,827 @@
+# Performance Check Analytics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add aggregate performance-check save counts to existing batch save analytics without treating missing performance-check records as vehicle save failures.
+
+**Architecture:** Keep the existing boundary: save workflow emits business facts, workflow analytics converts them into batch analytics input, and shared analytics is the only layer that knows Umami payload keys. Save results are threaded by prepared listing id so the adapter can count requested, saved, missing, and image totals per original preview batch. No raw CheckPaper URL, document bytes, or per-vehicle performance-check URL leaves the save flow.
+
+**Tech Stack:** Next.js App Router, TypeScript strict mode, Vitest, Zustand vanilla stores, existing Umami wrapper in `src/v2/shared/lib/analytics.ts`.
+
+---
+
+## File Structure
+
+- Modify `src/v2/shared/lib/analytics.ts`: Extend `BatchAnalyticsInput` and `toBatchEventData()` with optional performance-check aggregate fields.
+- Modify `src/v2/shared/lib/__tests__/analytics.test.ts`: Lock the shared payload contract and `save_completed` payload shape.
+- Modify `src/v2/application/truck-harvester-workflow/workflow-analytics.ts`: Extend `saveSettled` facts with save results and compute performance-check aggregates per save batch group.
+- Modify `src/v2/application/truck-harvester-workflow/workflow-analytics.test.ts`: Verify `saved`, `missing`, and `not_requested` stay distinct and do not create listing failure events.
+- Modify `src/v2/application/truck-harvester-workflow/save-workflow.ts`: Collect `TruckSaveResult` values by prepared listing id for directory and ZIP paths.
+- Modify `src/v2/application/truck-harvester-workflow/save-workflow.test.ts`: Verify directory and ZIP save results are passed into `saveSettled`.
+
+---
+
+### Task 1: Extend Shared Analytics Payload Contract
+
+**Files:**
+
+- Modify: `src/v2/shared/lib/analytics.ts`
+- Test: `src/v2/shared/lib/__tests__/analytics.test.ts`
+
+- [ ] **Step 1: Write the failing payload builder test**
+
+In `src/v2/shared/lib/__tests__/analytics.test.ts`, add this test inside `describe('analytics payload builders', () => { ... })` after the existing `builds batch event data with aggregate fields only` test:
+
+```ts
+it('builds batch event data with performance-check aggregates only as counts', () => {
+  const data = toBatchEventData({
+    batchId: 'batch-performance-checks',
+    urlCount: 4,
+    uniqueUrlCount: 4,
+    readyCount: 4,
+    invalidCount: 0,
+    previewFailedCount: 0,
+    savedCount: 4,
+    saveFailedCount: 0,
+    durationMs: 2400,
+    saveMethod: 'zip',
+    filesystemSupported: false,
+    notificationEnabled: true,
+    performanceCheckRequestedCount: 3,
+    performanceCheckSavedCount: 2,
+    performanceCheckMissingCount: 1,
+    performanceCheckImageCount: 5,
+  })
+
+  expect(data).toEqual({
+    batch_id: 'batch-performance-checks',
+    url_count: 4,
+    unique_url_count: 4,
+    ready_count: 4,
+    invalid_count: 0,
+    preview_failed_count: 0,
+    saved_count: 4,
+    save_failed_count: 0,
+    duration_ms: 2400,
+    save_method: 'zip',
+    filesystem_supported: false,
+    notification_enabled: true,
+    performance_check_requested_count: 3,
+    performance_check_saved_count: 2,
+    performance_check_missing_count: 1,
+    performance_check_image_count: 5,
+  })
+  expect(data).not.toHaveProperty('listing_url')
+  expect(data).not.toHaveProperty('vehicle_number')
+  expect(data).not.toHaveProperty('vehicle_name')
+  expect(data).not.toHaveProperty('performance_check_url')
+  expect(data).not.toHaveProperty('checkpaper_url')
+})
+```
+
+- [ ] **Step 2: Write the failing tracking test**
+
+In the existing `sends duration bucket with save_completed event data` test, add these fields to the `trackSaveCompleted({ ... })` input:
+
+```ts
+      performanceCheckRequestedCount: 3,
+      performanceCheckSavedCount: 2,
+      performanceCheckMissingCount: 1,
+      performanceCheckImageCount: 4,
+```
+
+Then add these expected fields to the `expect(track).toHaveBeenCalledWith('save_completed', { ... })` payload:
+
+```ts
+      performance_check_requested_count: 3,
+      performance_check_saved_count: 2,
+      performance_check_missing_count: 1,
+      performance_check_image_count: 4,
+```
+
+- [ ] **Step 3: Run the focused analytics test and verify it fails**
+
+Run:
+
+```bash
+bun run test -- --run src/v2/shared/lib/__tests__/analytics.test.ts
+```
+
+Expected: FAIL with TypeScript or assertion output showing the new `performanceCheck*` input fields are not part of `BatchAnalyticsInput` or are missing from payload output.
+
+- [ ] **Step 4: Extend `BatchAnalyticsInput`**
+
+In `src/v2/shared/lib/analytics.ts`, add these optional fields to `BatchAnalyticsInput` after `saveFailedCount`:
+
+```ts
+  performanceCheckRequestedCount?: number
+  performanceCheckSavedCount?: number
+  performanceCheckMissingCount?: number
+  performanceCheckImageCount?: number
+```
+
+- [ ] **Step 5: Emit compact Umami keys from `toBatchEventData()`**
+
+In `src/v2/shared/lib/analytics.ts`, add these entries inside the object passed to `compactEventData()` in `toBatchEventData()` after `save_failed_count`:
+
+```ts
+    performance_check_requested_count: input.performanceCheckRequestedCount,
+    performance_check_saved_count: input.performanceCheckSavedCount,
+    performance_check_missing_count: input.performanceCheckMissingCount,
+    performance_check_image_count: input.performanceCheckImageCount,
+```
+
+- [ ] **Step 6: Run the focused analytics test and verify it passes**
+
+Run:
+
+```bash
+bun run test -- --run src/v2/shared/lib/__tests__/analytics.test.ts
+```
+
+Expected: PASS. The shared transport accepts aggregate count fields and still omits per-listing identifiers from batch payloads.
+
+- [ ] **Step 7: Commit Task 1**
+
+Run:
+
+```bash
+git add src/v2/shared/lib/analytics.ts src/v2/shared/lib/__tests__/analytics.test.ts
+git commit -m "feat: 성능점검 analytics payload 확장"
+```
+
+---
+
+### Task 2: Thread Save Results Through The Workflow Boundary
+
+**Files:**
+
+- Modify: `src/v2/application/truck-harvester-workflow/workflow-analytics.ts`
+- Modify: `src/v2/application/truck-harvester-workflow/save-workflow.ts`
+- Test: `src/v2/application/truck-harvester-workflow/workflow-analytics.test.ts`
+- Test: `src/v2/application/truck-harvester-workflow/save-workflow.test.ts`
+
+- [ ] **Step 1: Extend the `saveSettled` fact type**
+
+In `src/v2/application/truck-harvester-workflow/workflow-analytics.ts`, update the imports to include `TruckSaveResult`:
+
+```ts
+import { type TruckSaveResult } from '@/v2/features/file-management'
+```
+
+Then update the `WorkflowTracker.saveSettled` event type from:
+
+```ts
+  saveSettled: (event: {
+    items: readonly WorkflowSaveItem[]
+    saveMethod: SaveMethod
+    savedItemIds: ReadonlySet<string>
+  }) => void
+```
+
+to:
+
+```ts
+  saveSettled: (event: {
+    items: readonly WorkflowSaveItem[]
+    saveMethod: SaveMethod
+    savedItemIds: ReadonlySet<string>
+    saveResultsByItemId: ReadonlyMap<string, TruckSaveResult>
+  }) => void
+```
+
+Leave the current `createWorkflowAnalytics().saveSettled` implementation destructuring as `({ items, saveMethod, savedItemIds })` in this task. TypeScript allows callers to provide the extra field while the implementation ignores it until Task 3.
+
+- [ ] **Step 2: Update existing workflow analytics test calls**
+
+In `src/v2/application/truck-harvester-workflow/workflow-analytics.test.ts`, update each existing `tracker.saveSettled({ ... })` call that does not yet test performance-check aggregates by adding:
+
+```ts
+      saveResultsByItemId: new Map(),
+```
+
+For the existing successful retry call that saves `item.id`, use an empty map in this task:
+
+```ts
+tracker.saveSettled({
+  items: [item],
+  saveMethod: 'directory',
+  savedItemIds: new Set([item.id]),
+  saveResultsByItemId: new Map(),
+})
+```
+
+- [ ] **Step 3: Update save workflow tests to expect save result maps**
+
+In `src/v2/application/truck-harvester-workflow/save-workflow.test.ts`, update the first directory success expectation to include the result map:
+
+```ts
+expect(tracker.saveSettled).toHaveBeenCalledWith({
+  items: [workflowItem],
+  saveMethod: 'directory',
+  savedItemIds: new Set(['listing-1']),
+  saveResultsByItemId: new Map([['listing-1', directorySaveResult]]),
+})
+```
+
+Update the directory failure expectation to include an empty map:
+
+```ts
+expect(tracker.saveSettled).toHaveBeenCalledWith({
+  items: [workflowItem],
+  saveMethod: 'directory',
+  savedItemIds: new Set(),
+  saveResultsByItemId: new Map(),
+})
+```
+
+In the `preserves ZIP save results on matching saved items` test, replace the inline ZIP result array with named constants before `downloadTruckZip`:
+
+```ts
+const secondZipSaveResult = {
+  performanceCheckImageCount: 0,
+  performanceCheckStatus: 'saved',
+  sourceUrl: secondUrl,
+  vehicleImageCount: 0,
+  vehicleImageStatus: 'complete',
+  vehicleImageTotalCount: 0,
+  vehicleFolderName: '부산34나7890',
+  vehicleNumber: '부산34나7890',
+} satisfies TruckSaveResult
+const firstZipSaveResult = missingPerformanceCheckResult
+const downloadTruckZip = vi.fn(async () => [secondZipSaveResult, firstZipSaveResult])
+```
+
+Then add this assertion at the end of that test:
+
+```ts
+expect(tracker.saveSettled).toHaveBeenCalledWith({
+  items: [
+    {
+      id: 'listing-1',
+      url: firstUrl,
+      listing,
+    },
+    {
+      id: 'listing-2',
+      url: secondUrl,
+      listing: secondListing,
+    },
+  ],
+  saveMethod: 'zip',
+  savedItemIds: new Set(['listing-1', 'listing-2']),
+  saveResultsByItemId: new Map([
+    ['listing-1', firstZipSaveResult],
+    ['listing-2', secondZipSaveResult],
+  ]),
+})
+```
+
+In the `does not attach mismatched ZIP results to the wrong saved item` test, add this assertion after the existing `tracker.saveListingFailed` expectation:
+
+```ts
+expect(tracker.saveSettled).toHaveBeenCalledWith({
+  items: [
+    {
+      id: 'listing-1',
+      url: firstUrl,
+      listing,
+    },
+    {
+      id: 'listing-2',
+      url: secondUrl,
+      listing: secondListing,
+    },
+  ],
+  saveMethod: 'zip',
+  savedItemIds: new Set(['listing-1']),
+  saveResultsByItemId: new Map([
+    [
+      'listing-1',
+      {
+        ...missingPerformanceCheckResult,
+        sourceUrl: firstUrl,
+      },
+    ],
+  ]),
+})
+```
+
+- [ ] **Step 4: Run the focused save workflow test and verify it fails**
+
+Run:
+
+```bash
+bun run test -- --run src/v2/application/truck-harvester-workflow/save-workflow.test.ts
+```
+
+Expected: FAIL because `saveSettled` calls do not yet include `saveResultsByItemId`.
+
+- [ ] **Step 5: Collect directory and ZIP save results by prepared listing id**
+
+In `src/v2/application/truck-harvester-workflow/save-workflow.ts`, add the map beside `savedItemIds`:
+
+```ts
+const savedItemIds = new Set<string>()
+const saveResultsByItemId = new Map<string, TruckSaveResult>()
+```
+
+In the directory save path, after `saveTruckToDirectory(...)` resolves and before `store.getState().markSaved(item.id, saveResult)`, add:
+
+```ts
+saveResultsByItemId.set(item.id, saveResult)
+```
+
+In the ZIP matched result path, after the `if (!saveResult) { ... return }` block and before `store.getState().markSaved(item.id, saveResult)`, add:
+
+```ts
+saveResultsByItemId.set(item.id, saveResult)
+```
+
+Update the final `tracker.saveSettled({ ... })` call to include:
+
+```ts
+    saveResultsByItemId,
+```
+
+The final call should be:
+
+```ts
+tracker.saveSettled({
+  items: workflowItems,
+  saveMethod,
+  savedItemIds,
+  saveResultsByItemId,
+})
+```
+
+- [ ] **Step 6: Run focused workflow tests and verify they pass**
+
+Run:
+
+```bash
+bun run test -- --run src/v2/application/truck-harvester-workflow/save-workflow.test.ts src/v2/application/truck-harvester-workflow/workflow-analytics.test.ts
+```
+
+Expected: PASS. The save workflow passes result maps, and the analytics adapter still behaves as before because it ignores the map until Task 3.
+
+- [ ] **Step 7: Run typecheck**
+
+Run:
+
+```bash
+bun run typecheck
+```
+
+Expected: PASS. All `WorkflowTracker.saveSettled` callers include `saveResultsByItemId`.
+
+- [ ] **Step 8: Commit Task 2**
+
+Run:
+
+```bash
+git add src/v2/application/truck-harvester-workflow/workflow-analytics.ts src/v2/application/truck-harvester-workflow/save-workflow.ts src/v2/application/truck-harvester-workflow/workflow-analytics.test.ts src/v2/application/truck-harvester-workflow/save-workflow.test.ts
+git commit -m "feat: 저장 결과를 workflow analytics에 전달"
+```
+
+---
+
+### Task 3: Compute Performance-Check Aggregates In Workflow Analytics
+
+**Files:**
+
+- Modify: `src/v2/application/truck-harvester-workflow/workflow-analytics.ts`
+- Test: `src/v2/application/truck-harvester-workflow/workflow-analytics.test.ts`
+
+- [ ] **Step 1: Add workflow analytics test fixtures**
+
+In `src/v2/application/truck-harvester-workflow/workflow-analytics.test.ts`, update the imports to include `TruckSaveResult`:
+
+```ts
+import { type TruckSaveResult } from '@/v2/features/file-management'
+```
+
+After the existing `listing` fixture, add this helper:
+
+```ts
+const createSaveResult = (overrides: Partial<TruckSaveResult> = {}): TruckSaveResult => ({
+  performanceCheckImageCount: 0,
+  performanceCheckStatus: 'not_requested',
+  sourceUrl: firstUrl,
+  vehicleImageCount: 1,
+  vehicleImageStatus: 'complete',
+  vehicleImageTotalCount: 1,
+  vehicleFolderName: '서울12가3456',
+  vehicleNumber: '서울12가3456',
+  ...overrides,
+})
+```
+
+- [ ] **Step 2: Write the failing aggregate success test**
+
+In `src/v2/application/truck-harvester-workflow/workflow-analytics.test.ts`, add this test inside `describe('workflow analytics adapter', () => { ... })` after the existing `tracks save batches separately by original preview batch` test:
+
+```ts
+it('adds performance-check aggregates to save completed events without listing failures for missing records', () => {
+  const transport = createTransport()
+  const tracker = createWorkflowAnalytics({
+    createBatchId: () => 'batch-performance-checks',
+    getFilesystemSupported: () => true,
+    getNotificationEnabled: () => false,
+    now: () => 300,
+    transport,
+  })
+  const batch = tracker.previewStarted({ urlCount: 3, startedAt: 100 })
+  const savedCheckListing = {
+    ...listing,
+    performanceCheckUrl: 'https://check.example.com/saved',
+  }
+  const missingCheckListing = {
+    ...listing,
+    url: secondUrl,
+    vnumber: '부산34나7890',
+    performanceCheckUrl: 'https://check.example.com/missing',
+  }
+  const notRequestedListing = {
+    ...listing,
+    url: thirdUrl,
+    vnumber: '대구56다1234',
+    performanceCheckUrl: undefined,
+  }
+
+  tracker.previewCompleted({
+    batch,
+    items: [
+      { id: 'listing-1', url: firstUrl, status: 'ready' },
+      { id: 'listing-2', url: secondUrl, status: 'ready' },
+      { id: 'listing-3', url: thirdUrl, status: 'ready' },
+    ],
+  })
+  tracker.saveSettled({
+    items: [
+      { id: 'listing-1', url: firstUrl, listing: savedCheckListing },
+      { id: 'listing-2', url: secondUrl, listing: missingCheckListing },
+      { id: 'listing-3', url: thirdUrl, listing: notRequestedListing },
+    ],
+    saveMethod: 'directory',
+    savedItemIds: new Set(['listing-1', 'listing-2', 'listing-3']),
+    saveResultsByItemId: new Map([
+      [
+        'listing-1',
+        createSaveResult({
+          performanceCheckImageCount: 2,
+          performanceCheckStatus: 'saved',
+          sourceUrl: firstUrl,
+        }),
+      ],
+      [
+        'listing-2',
+        createSaveResult({
+          performanceCheckImageCount: 0,
+          performanceCheckStatus: 'missing',
+          sourceUrl: secondUrl,
+          vehicleFolderName: '부산34나7890',
+          vehicleNumber: '부산34나7890',
+        }),
+      ],
+      [
+        'listing-3',
+        createSaveResult({
+          performanceCheckImageCount: 0,
+          performanceCheckStatus: 'not_requested',
+          sourceUrl: thirdUrl,
+          vehicleFolderName: '대구56다1234',
+          vehicleNumber: '대구56다1234',
+        }),
+      ],
+    ]),
+  })
+
+  expect(transport.trackSaveCompleted).toHaveBeenCalledWith(
+    expect.objectContaining({
+      batchId: 'batch-performance-checks',
+      savedCount: 3,
+      saveFailedCount: 0,
+      performanceCheckRequestedCount: 2,
+      performanceCheckSavedCount: 1,
+      performanceCheckMissingCount: 1,
+      performanceCheckImageCount: 2,
+    })
+  )
+  expect(transport.trackListingFailed).not.toHaveBeenCalled()
+})
+```
+
+- [ ] **Step 3: Write the failing partial-save test**
+
+In `src/v2/application/truck-harvester-workflow/workflow-analytics.test.ts`, add this test after the test from Step 2:
+
+```ts
+it('keeps performance-check aggregates separate from vehicle save failures', () => {
+  const transport = createTransport()
+  const tracker = createWorkflowAnalytics({
+    createBatchId: () => 'batch-partial-performance-checks',
+    getFilesystemSupported: () => true,
+    getNotificationEnabled: () => false,
+    now: () => 400,
+    transport,
+  })
+  const batch = tracker.previewStarted({ urlCount: 2, startedAt: 100 })
+  const savedItem = {
+    id: 'listing-1',
+    url: firstUrl,
+    listing: {
+      ...listing,
+      performanceCheckUrl: 'https://check.example.com/saved',
+    },
+  }
+  const failedItem = {
+    id: 'listing-2',
+    url: secondUrl,
+    listing: {
+      ...listing,
+      url: secondUrl,
+      vnumber: '부산34나7890',
+      performanceCheckUrl: 'https://check.example.com/not-saved',
+    },
+  }
+
+  tracker.previewCompleted({
+    batch,
+    items: [
+      { id: savedItem.id, url: savedItem.url, status: 'ready' },
+      { id: failedItem.id, url: failedItem.url, status: 'ready' },
+    ],
+  })
+  tracker.saveListingFailed({
+    item: failedItem,
+    message: '저장하지 못했어요.',
+  })
+  tracker.saveSettled({
+    items: [savedItem, failedItem],
+    saveMethod: 'directory',
+    savedItemIds: new Set([savedItem.id]),
+    saveResultsByItemId: new Map([
+      [
+        savedItem.id,
+        createSaveResult({
+          performanceCheckImageCount: 1,
+          performanceCheckStatus: 'saved',
+          sourceUrl: firstUrl,
+        }),
+      ],
+    ]),
+  })
+
+  expect(transport.trackSaveFailed).toHaveBeenCalledWith(
+    expect.objectContaining({
+      batchId: 'batch-partial-performance-checks',
+      savedCount: 1,
+      saveFailedCount: 1,
+      performanceCheckRequestedCount: 2,
+      performanceCheckSavedCount: 1,
+      performanceCheckMissingCount: 0,
+      performanceCheckImageCount: 1,
+    })
+  )
+  expect(transport.trackListingFailed).toHaveBeenCalledTimes(1)
+  expect(transport.trackListingFailed).toHaveBeenCalledWith(
+    expect.objectContaining({
+      batchId: 'batch-partial-performance-checks',
+      failureStage: 'save',
+      listingUrl: secondUrl,
+    })
+  )
+})
+```
+
+- [ ] **Step 4: Run the focused workflow analytics test and verify it fails**
+
+Run:
+
+```bash
+bun run test -- --run src/v2/application/truck-harvester-workflow/workflow-analytics.test.ts
+```
+
+Expected: FAIL because `trackSaveCompleted` and `trackSaveFailed` inputs do not include the new performance-check aggregate fields.
+
+- [ ] **Step 5: Add performance-check aggregate helpers**
+
+In `src/v2/application/truck-harvester-workflow/workflow-analytics.ts`, add this interface after `interface SaveBatchGroup`:
+
+```ts
+interface PerformanceCheckBatchCounts {
+  performanceCheckRequestedCount: number
+  performanceCheckSavedCount: number
+  performanceCheckMissingCount: number
+  performanceCheckImageCount: number
+}
+```
+
+Add this helper near the existing `getSaveCounts` helper:
+
+```ts
+const hasRequestedPerformanceCheck = (listing: TruckListing) =>
+  Boolean(listing.performanceCheckUrl?.trim())
+
+const getPerformanceCheckCounts = (
+  group: SaveBatchGroup,
+  saveResultsByItemId: ReadonlyMap<string, TruckSaveResult>
+): PerformanceCheckBatchCounts => {
+  let performanceCheckRequestedCount = 0
+  let performanceCheckSavedCount = 0
+  let performanceCheckMissingCount = 0
+  let performanceCheckImageCount = 0
+
+  group.items.forEach((item) => {
+    const requested = hasRequestedPerformanceCheck(item.listing)
+
+    if (requested) {
+      performanceCheckRequestedCount += 1
+    }
+
+    const result = saveResultsByItemId.get(item.id)
+
+    if (!result) {
+      return
+    }
+
+    if (result.performanceCheckStatus === 'saved') {
+      performanceCheckSavedCount += 1
+    }
+
+    if (requested && result.performanceCheckStatus === 'missing') {
+      performanceCheckMissingCount += 1
+    }
+
+    performanceCheckImageCount += result.performanceCheckImageCount
+  })
+
+  return {
+    performanceCheckRequestedCount,
+    performanceCheckSavedCount,
+    performanceCheckMissingCount,
+    performanceCheckImageCount,
+  }
+}
+```
+
+- [ ] **Step 6: Thread aggregate counts through `toBatchInput()`**
+
+In `src/v2/application/truck-harvester-workflow/workflow-analytics.ts`, extend the `toBatchInput()` options type to include `performanceCheckCounts`:
+
+```ts
+      performanceCheckCounts?: PerformanceCheckBatchCounts
+```
+
+Then add these fields to the `BatchAnalyticsInput` object returned by `toBatchInput()` after `saveFailedCount`:
+
+```ts
+    performanceCheckRequestedCount:
+      options.performanceCheckCounts?.performanceCheckRequestedCount,
+    performanceCheckSavedCount:
+      options.performanceCheckCounts?.performanceCheckSavedCount,
+    performanceCheckMissingCount:
+      options.performanceCheckCounts?.performanceCheckMissingCount,
+    performanceCheckImageCount:
+      options.performanceCheckCounts?.performanceCheckImageCount,
+```
+
+- [ ] **Step 7: Use save result maps during settlement**
+
+In `src/v2/application/truck-harvester-workflow/workflow-analytics.ts`, change the `saveSettled` implementation signature from:
+
+```ts
+    saveSettled: ({ items, saveMethod, savedItemIds }) => {
+```
+
+to:
+
+```ts
+    saveSettled: ({ items, saveMethod, savedItemIds, saveResultsByItemId }) => {
+```
+
+Inside the `getSaveGroups(items).forEach((group) => { ... })` block, add:
+
+```ts
+const performanceCheckCounts = getPerformanceCheckCounts(group, saveResultsByItemId)
+```
+
+Then include `performanceCheckCounts` in the `toBatchInput()` options object:
+
+```ts
+            ...counts,
+            saveMethod,
+            performanceCheckCounts,
+```
+
+- [ ] **Step 8: Run the focused workflow analytics test and verify it passes**
+
+Run:
+
+```bash
+bun run test -- --run src/v2/application/truck-harvester-workflow/workflow-analytics.test.ts
+```
+
+Expected: PASS. Missing performance-check records are aggregate counts, not listing failure events.
+
+- [ ] **Step 9: Run the focused save workflow test again**
+
+Run:
+
+```bash
+bun run test -- --run src/v2/application/truck-harvester-workflow/save-workflow.test.ts
+```
+
+Expected: PASS. The save workflow still supplies result maps in both directory and ZIP paths.
+
+- [ ] **Step 10: Commit Task 3**
+
+Run:
+
+```bash
+git add src/v2/application/truck-harvester-workflow/workflow-analytics.ts src/v2/application/truck-harvester-workflow/workflow-analytics.test.ts src/v2/application/truck-harvester-workflow/save-workflow.test.ts
+git commit -m "feat: 성능점검 저장 결과 analytics 집계"
+```
+
+---
+
+### Task 4: Full Verification
+
+**Files:**
+
+- Verify: all modified source and test files
+
+- [ ] **Step 1: Run typecheck**
+
+Run:
+
+```bash
+bun run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run lint**
+
+Run:
+
+```bash
+bun run lint
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run format check**
+
+Run:
+
+```bash
+bun run format:check
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run the unit test suite**
+
+Run:
+
+```bash
+bun run test -- --run
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run build**
+
+Run:
+
+```bash
+bun run build
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Inspect the final diff**
+
+Run:
+
+```bash
+git diff --stat main...HEAD
+git diff main...HEAD -- src/v2/shared/lib/analytics.ts src/v2/application/truck-harvester-workflow/workflow-analytics.ts src/v2/application/truck-harvester-workflow/save-workflow.ts
+```
+
+Expected: The diff only extends analytics counts and save result threading. It does not modify CheckPaper renderer logic, folder layout, UI copy, or failed-listing diagnostic policy.
+The full branch diff may also include the approved design and plan docs under
+`docs/superpowers/`.
+
+- [ ] **Step 7: Commit verification fixes if any were required**
+
+If Step 1-5 forced formatting or test-only fixes, commit them:
+
+```bash
+git add src/v2/shared/lib/analytics.ts src/v2/shared/lib/__tests__/analytics.test.ts src/v2/application/truck-harvester-workflow/workflow-analytics.ts src/v2/application/truck-harvester-workflow/workflow-analytics.test.ts src/v2/application/truck-harvester-workflow/save-workflow.ts src/v2/application/truck-harvester-workflow/save-workflow.test.ts
+git commit -m "test: 성능점검 analytics 검증 보강"
+```
+
+Expected: No commit is needed when Step 1-5 pass without changing files.

--- a/docs/superpowers/specs/2026-06-25-performance-check-analytics-design.md
+++ b/docs/superpowers/specs/2026-06-25-performance-check-analytics-design.md
@@ -1,0 +1,185 @@
+# 성능점검기록부 저장 analytics 설계
+
+작성일: 2026-06-25
+
+## 배경
+
+Truck Harvester는 매물 저장 시 차량 이미지, 성능점검기록부 JPG, 원고를
+차량별 폴더나 ZIP으로 저장한다. 성능점검기록부는 매물 parser가 찾은
+`performanceCheckUrl`이 있을 때만 저장을 시도하며, 저장하지 못해도 차량
+이미지와 원고 저장은 성공으로 처리한다.
+
+현재 analytics는 batch 단위의 붙여넣기, 미리보기, 저장 funnel을 기록한다.
+성능점검기록부 저장 결과는 `TruckSaveResult`와 prepared listing state에는
+남지만, Umami aggregate event에는 반영되지 않는다. 따라서 운영자가 "저장은
+성공했는데 성능점검기록부가 얼마나 저장됐는지"를 batch 수준에서 볼 수 없다.
+
+## 목표
+
+- 저장 완료 batch analytics에 성능점검기록부 aggregate 결과를 추가한다.
+- 성능점검기록부 저장 실패를 차량 저장 실패로 기록하지 않는다.
+- `not_requested`와 `missing`을 analytics에서 분리한다.
+- raw CheckPaper URL, 차량별 성능점검기록부 URL, 원본 문서 내용은 보내지
+  않는다.
+- UI 컴포넌트가 `window.umami`나 analytics payload field를 직접 알지 않는
+  기존 경계를 유지한다.
+
+## 비목표
+
+- 새 Umami event name을 추가하지 않는다.
+- 성능점검기록부 missing을 `listing_failed`나 `save_failed`의 개별 실패로
+  기록하지 않는다.
+- 저장 폴더 구조, 완료 요약 UI, CheckPaper renderer 동작을 바꾸지 않는다.
+- 기존 preview analytics나 failed-listing diagnostic 수집 범위를 넓히지
+  않는다.
+- 새 `listing_count` field를 만들지 않는다. 현재 batch contract의
+  `url_count`, `unique_url_count`, `ready_count`를 그대로 사용한다.
+
+## 확정 접근
+
+기존 batch save event payload를 확장한다.
+
+`runSaveWorkflow`는 directory 저장과 ZIP fallback에서 받은 `TruckSaveResult`를
+listing id와 연결해 `workflow-analytics`의 `saveSettled` fact로 전달한다.
+`workflow-analytics`는 batch group별로 저장 결과를 집계하고, 기존
+`trackSaveCompleted` 또는 `trackSaveFailed` input에 성능점검기록부 aggregate
+field를 추가한다.
+
+이 방식은 현재 "business fact -> workflow analytics adapter -> shared
+analytics transport" 경계를 유지한다. `src/v2/shared/lib/analytics.ts`만 concrete
+Umami payload key를 알고, UI와 save workflow는 Umami event name을 알지 않는다.
+
+## Payload contract
+
+`save_completed`와 batch-level `save_failed` payload에 아래 optional aggregate
+fields를 추가한다.
+
+```text
+performance_check_requested_count
+performance_check_saved_count
+performance_check_missing_count
+performance_check_image_count
+```
+
+기존 batch fields는 유지한다.
+
+```text
+batch_id
+url_count
+unique_url_count
+ready_count
+invalid_count
+preview_failed_count
+saved_count
+save_failed_count
+duration_ms
+duration_bucket
+save_method
+filesystem_supported
+notification_enabled
+```
+
+`duration_bucket`은 기존처럼 `save_completed`에서만 붙인다. 성능점검기록부
+aggregate fields는 저장 결과를 알 수 있는 settled event에만 붙이고,
+`batch_started`, `preview_completed`, `save_started`, `listing_failed`에는 붙이지
+않는다.
+
+## Counting rules
+
+성능점검기록부 count는 batch group 안의 저장 대상 ready listings를 기준으로
+계산한다.
+
+- `performance_check_requested_count`: `listing.performanceCheckUrl`이 비어 있지
+  않은 저장 대상 수.
+- `performance_check_saved_count`: 저장 결과가
+  `performanceCheckStatus === 'saved'`인 수.
+- `performance_check_missing_count`: `listing.performanceCheckUrl`이 있었고 저장
+  결과가 `performanceCheckStatus === 'missing'`인 수.
+- `performance_check_image_count`: 저장 결과의
+  `performanceCheckImageCount` 합계.
+
+`performanceCheckStatus === 'not_requested'`는 missing에 포함하지 않는다. 매물에
+성능점검기록부 링크가 없었던 차량과 링크가 있었지만 저장하지 못한 차량은 원인이
+다르므로, analytics에서도 섞지 않는다.
+
+저장 자체가 실패한 차량은 저장 결과가 없을 수 있다. 이 경우 requested count는
+listing의 `performanceCheckUrl`로 계산하지만, saved/image count에는 반영하지
+않는다. 성능점검기록부 때문에 차량 저장 실패가 발생한 것처럼 기록하지 않는다.
+
+## Data flow
+
+```text
+save-workflow
+  -> saveTruckToDirectory() or downloadTruckZip()
+  -> collect TruckSaveResult by prepared listing id
+  -> tracker.saveSettled({ savedItemIds, saveResultsByItemId })
+  -> workflow-analytics groups listings by original preview batch
+  -> workflow-analytics computes performance-check aggregates per group
+  -> shared analytics transport emits save_completed or batch-level save_failed
+```
+
+Directory 저장은 listing 하나를 저장할 때마다 `TruckSaveResult`를 바로 item id에
+연결한다. ZIP fallback은 `sourceUrl`로 반환 결과를 matching한 뒤, matched result를
+item id에 연결한다. 기존 ZIP mismatch 처리처럼 matching되지 않은 item은 차량 저장
+실패로 처리하고, 성능점검기록부 saved/image count에는 포함하지 않는다.
+
+## Privacy and safety
+
+성능점검기록부 analytics는 count만 보낸다. 보내지 않는 값은 명시적으로 다음과
+같다.
+
+- raw CheckPaper URL
+- 차량별 `performanceCheckUrl`
+- CheckPaper HTML, PDF, JPG bytes, 문서 텍스트
+- renderer provider, redirect URL, asset URL
+
+기존 failed-listing diagnostic 예외는 그대로 유지한다. 즉 개별 URL, 차량번호,
+차명, 이미지 수는 preview/save listing failure event에서만 허용되며,
+성능점검기록부 missing은 이 event를 만들지 않는다.
+
+Analytics 호출 실패는 기존 transport처럼 사용자 저장 흐름을 중단하지 않는다.
+
+## Error handling
+
+- 성능점검기록부 URL이 없으면 requested count에 포함하지 않는다.
+- URL이 있었지만 capture 결과가 없거나 renderer가 실패해 `missing`이 되면
+  missing count에 포함한다.
+- 성능점검기록부가 missing이어도 `savedItemIds`에는 영향을 주지 않는다.
+- 차량 이미지나 원고 저장 실패처럼 차량 저장 자체가 실패한 경우에만 기존
+  `saveListingFailed` 흐름을 사용한다.
+- Abort 이후에는 기존처럼 save settlement analytics를 보내지 않는다.
+
+## Testing plan
+
+- `src/v2/shared/lib/__tests__/analytics.test.ts`
+  - `toBatchEventData`가 성능점검기록부 aggregate fields를 포함한다.
+  - aggregate payload에 raw URL, 차량번호, 차명, 문서 내용 field가 섞이지
+    않는다.
+  - `trackSaveCompleted`는 기존 `duration_bucket`과 새 aggregate fields를 함께
+    보낸다.
+- `src/v2/application/truck-harvester-workflow/workflow-analytics.test.ts`
+  - `saved`, `missing`, `not_requested`를 분리해 batch group별 count를 계산한다.
+  - 성능점검기록부 missing이 `trackListingFailed`를 만들지 않는다.
+  - 일부 차량 저장 실패가 있어도 requested count와 saved/image count가 각각
+    올바르게 계산된다.
+- `src/v2/application/truck-harvester-workflow/save-workflow.test.ts`
+  - directory save result가 `saveSettled`에 item id별로 전달된다.
+  - ZIP save result가 `sourceUrl` matching 뒤 `saveSettled`에 전달된다.
+  - cancellation path는 기존처럼 settlement를 보내지 않는다.
+
+## Implementation boundary
+
+변경 파일은 analytics transport, workflow analytics adapter, save workflow,
+그리고 해당 unit tests로 제한한다. File System Access API 구현, ZIP archive
+구조, CheckPaper capture/renderer, prepared listing UI는 이번 변경에서 건드리지
+않는다.
+
+구현 후 최소 검증은 다음 명령으로 한다.
+
+```bash
+bun run typecheck
+bun run lint
+bun run format:check
+bun run test -- --run
+bun run build
+```

--- a/src/v2/application/truck-harvester-workflow/save-workflow.test.ts
+++ b/src/v2/application/truck-harvester-workflow/save-workflow.test.ts
@@ -129,6 +129,7 @@ describe('runSaveWorkflow', () => {
       items: [workflowItem],
       saveMethod: 'directory',
       savedItemIds: new Set(['listing-1']),
+      saveResultsByItemId: new Map([['listing-1', directorySaveResult]]),
     })
   })
 
@@ -194,6 +195,7 @@ describe('runSaveWorkflow', () => {
       items: [workflowItem],
       saveMethod: 'directory',
       savedItemIds: new Set(),
+      saveResultsByItemId: new Map(),
     })
   })
 
@@ -268,18 +270,20 @@ describe('runSaveWorkflow', () => {
     }
     const items = addReadyListings(store, [listing, secondListing])
     const tracker = createTracker()
+    const secondZipSaveResult = {
+      performanceCheckImageCount: 0,
+      performanceCheckStatus: 'saved',
+      sourceUrl: secondUrl,
+      vehicleImageCount: 0,
+      vehicleImageStatus: 'complete',
+      vehicleImageTotalCount: 0,
+      vehicleFolderName: '부산34나7890',
+      vehicleNumber: '부산34나7890',
+    } satisfies TruckSaveResult
+    const firstZipSaveResult = missingPerformanceCheckResult
     const downloadTruckZip = vi.fn(async () => [
-      {
-        performanceCheckImageCount: 0,
-        performanceCheckStatus: 'saved',
-        sourceUrl: secondUrl,
-        vehicleImageCount: 0,
-        vehicleImageStatus: 'complete',
-        vehicleImageTotalCount: 0,
-        vehicleFolderName: '부산34나7890',
-        vehicleNumber: '부산34나7890',
-      } satisfies TruckSaveResult,
-      missingPerformanceCheckResult,
+      secondZipSaveResult,
+      firstZipSaveResult,
     ])
 
     await runSaveWorkflow({
@@ -306,6 +310,26 @@ describe('runSaveWorkflow', () => {
         vehicleImageStatus: 'complete',
       },
     ])
+    expect(tracker.saveSettled).toHaveBeenCalledWith({
+      items: [
+        {
+          id: 'listing-1',
+          url: firstUrl,
+          listing,
+        },
+        {
+          id: 'listing-2',
+          url: secondUrl,
+          listing: secondListing,
+        },
+      ],
+      saveMethod: 'zip',
+      savedItemIds: new Set(['listing-1', 'listing-2']),
+      saveResultsByItemId: new Map([
+        ['listing-1', firstZipSaveResult],
+        ['listing-2', secondZipSaveResult],
+      ]),
+    })
   })
 
   it('does not attach mismatched ZIP results to the wrong saved item', async () => {
@@ -352,6 +376,31 @@ describe('runSaveWorkflow', () => {
         listing: secondListing,
       },
       message: saveFailureMessage,
+    })
+    expect(tracker.saveSettled).toHaveBeenCalledWith({
+      items: [
+        {
+          id: 'listing-1',
+          url: firstUrl,
+          listing,
+        },
+        {
+          id: 'listing-2',
+          url: secondUrl,
+          listing: secondListing,
+        },
+      ],
+      saveMethod: 'zip',
+      savedItemIds: new Set(['listing-1']),
+      saveResultsByItemId: new Map([
+        [
+          'listing-1',
+          {
+            ...missingPerformanceCheckResult,
+            sourceUrl: firstUrl,
+          },
+        ],
+      ]),
     })
   })
 

--- a/src/v2/application/truck-harvester-workflow/save-workflow.ts
+++ b/src/v2/application/truck-harvester-workflow/save-workflow.ts
@@ -81,6 +81,7 @@ export async function runSaveWorkflow({
 
   const workflowItems = items.map(toWorkflowSaveItem)
   const savedItemIds = new Set<string>()
+  const saveResultsByItemId = new Map<string, TruckSaveResult>()
 
   tracker.saveStarted({ items: workflowItems, saveMethod })
 
@@ -114,6 +115,7 @@ export async function runSaveWorkflow({
           return { savedCount }
         }
 
+        saveResultsByItemId.set(item.id, saveResult)
         store.getState().markSaved(item.id, saveResult)
         savedItemIds.add(item.id)
         savedCount += 1
@@ -179,6 +181,7 @@ export async function runSaveWorkflow({
           return
         }
 
+        saveResultsByItemId.set(item.id, saveResult)
         store.getState().markSaved(item.id, saveResult)
         savedItemIds.add(item.id)
         savedCount += 1
@@ -208,6 +211,7 @@ export async function runSaveWorkflow({
     items: workflowItems,
     saveMethod,
     savedItemIds,
+    saveResultsByItemId,
   })
 
   return { savedCount }

--- a/src/v2/application/truck-harvester-workflow/workflow-analytics.test.ts
+++ b/src/v2/application/truck-harvester-workflow/workflow-analytics.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import { type TruckListing } from '@/v2/entities/truck'
+import { type TruckSaveResult } from '@/v2/features/file-management'
 
 import { createWorkflowAnalytics } from './workflow-analytics'
 
@@ -25,6 +26,20 @@ const listing: TruckListing = {
   options: '윙바디',
   images: ['https://img.example.com/1.jpg'],
 }
+
+const createSaveResult = (
+  overrides: Partial<TruckSaveResult> = {}
+): TruckSaveResult => ({
+  performanceCheckImageCount: 0,
+  performanceCheckStatus: 'not_requested',
+  sourceUrl: firstUrl,
+  vehicleImageCount: 1,
+  vehicleImageStatus: 'complete',
+  vehicleImageTotalCount: 1,
+  vehicleFolderName: '서울12가3456',
+  vehicleNumber: '서울12가3456',
+  ...overrides,
+})
 
 const createTransport = () => ({
   trackBatchStarted: vi.fn(),
@@ -227,6 +242,172 @@ describe('workflow analytics adapter', () => {
         batchId: 'batch-save-second',
         savedCount: 0,
         saveFailedCount: 1,
+      })
+    )
+  })
+
+  it('adds performance-check aggregates to save completed events without listing failures for missing records', () => {
+    const transport = createTransport()
+    const tracker = createWorkflowAnalytics({
+      createBatchId: () => 'batch-performance-checks',
+      getFilesystemSupported: () => true,
+      getNotificationEnabled: () => false,
+      now: () => 300,
+      transport,
+    })
+    const batch = tracker.previewStarted({ urlCount: 3, startedAt: 100 })
+    const savedCheckListing = {
+      ...listing,
+      performanceCheckUrl: 'https://check.example.com/saved',
+    }
+    const missingCheckListing = {
+      ...listing,
+      url: secondUrl,
+      vnumber: '부산34나7890',
+      performanceCheckUrl: 'https://check.example.com/missing',
+    }
+    const notRequestedListing = {
+      ...listing,
+      url: thirdUrl,
+      vnumber: '대구56다1234',
+      performanceCheckUrl: undefined,
+    }
+
+    tracker.previewCompleted({
+      batch,
+      items: [
+        { id: 'listing-1', url: firstUrl, status: 'ready' },
+        { id: 'listing-2', url: secondUrl, status: 'ready' },
+        { id: 'listing-3', url: thirdUrl, status: 'ready' },
+      ],
+    })
+    tracker.saveSettled({
+      items: [
+        { id: 'listing-1', url: firstUrl, listing: savedCheckListing },
+        { id: 'listing-2', url: secondUrl, listing: missingCheckListing },
+        { id: 'listing-3', url: thirdUrl, listing: notRequestedListing },
+      ],
+      saveMethod: 'directory',
+      savedItemIds: new Set(['listing-1', 'listing-2', 'listing-3']),
+      saveResultsByItemId: new Map([
+        [
+          'listing-1',
+          createSaveResult({
+            performanceCheckImageCount: 2,
+            performanceCheckStatus: 'saved',
+            sourceUrl: firstUrl,
+          }),
+        ],
+        [
+          'listing-2',
+          createSaveResult({
+            performanceCheckImageCount: 0,
+            performanceCheckStatus: 'missing',
+            sourceUrl: secondUrl,
+            vehicleFolderName: '부산34나7890',
+            vehicleNumber: '부산34나7890',
+          }),
+        ],
+        [
+          'listing-3',
+          createSaveResult({
+            performanceCheckImageCount: 0,
+            performanceCheckStatus: 'not_requested',
+            sourceUrl: thirdUrl,
+            vehicleFolderName: '대구56다1234',
+            vehicleNumber: '대구56다1234',
+          }),
+        ],
+      ]),
+    })
+
+    expect(transport.trackSaveCompleted).toHaveBeenCalledWith(
+      expect.objectContaining({
+        batchId: 'batch-performance-checks',
+        savedCount: 3,
+        saveFailedCount: 0,
+        performanceCheckRequestedCount: 2,
+        performanceCheckSavedCount: 1,
+        performanceCheckMissingCount: 1,
+        performanceCheckImageCount: 2,
+      })
+    )
+    expect(transport.trackListingFailed).not.toHaveBeenCalled()
+  })
+
+  it('keeps performance-check aggregates separate from vehicle save failures', () => {
+    const transport = createTransport()
+    const tracker = createWorkflowAnalytics({
+      createBatchId: () => 'batch-partial-performance-checks',
+      getFilesystemSupported: () => true,
+      getNotificationEnabled: () => false,
+      now: () => 400,
+      transport,
+    })
+    const batch = tracker.previewStarted({ urlCount: 2, startedAt: 100 })
+    const savedItem = {
+      id: 'listing-1',
+      url: firstUrl,
+      listing: {
+        ...listing,
+        performanceCheckUrl: 'https://check.example.com/saved',
+      },
+    }
+    const failedItem = {
+      id: 'listing-2',
+      url: secondUrl,
+      listing: {
+        ...listing,
+        url: secondUrl,
+        vnumber: '부산34나7890',
+        performanceCheckUrl: 'https://check.example.com/not-saved',
+      },
+    }
+
+    tracker.previewCompleted({
+      batch,
+      items: [
+        { id: savedItem.id, url: savedItem.url, status: 'ready' },
+        { id: failedItem.id, url: failedItem.url, status: 'ready' },
+      ],
+    })
+    tracker.saveListingFailed({
+      item: failedItem,
+      message: '저장하지 못했어요.',
+    })
+    tracker.saveSettled({
+      items: [savedItem, failedItem],
+      saveMethod: 'directory',
+      savedItemIds: new Set([savedItem.id]),
+      saveResultsByItemId: new Map([
+        [
+          savedItem.id,
+          createSaveResult({
+            performanceCheckImageCount: 1,
+            performanceCheckStatus: 'saved',
+            sourceUrl: firstUrl,
+          }),
+        ],
+      ]),
+    })
+
+    expect(transport.trackSaveFailed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        batchId: 'batch-partial-performance-checks',
+        savedCount: 1,
+        saveFailedCount: 1,
+        performanceCheckRequestedCount: 2,
+        performanceCheckSavedCount: 1,
+        performanceCheckMissingCount: 0,
+        performanceCheckImageCount: 1,
+      })
+    )
+    expect(transport.trackListingFailed).toHaveBeenCalledTimes(1)
+    expect(transport.trackListingFailed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        batchId: 'batch-partial-performance-checks',
+        failureStage: 'save',
+        listingUrl: secondUrl,
       })
     )
   })

--- a/src/v2/application/truck-harvester-workflow/workflow-analytics.test.ts
+++ b/src/v2/application/truck-harvester-workflow/workflow-analytics.test.ts
@@ -335,6 +335,52 @@ describe('workflow analytics adapter', () => {
     expect(transport.trackListingFailed).not.toHaveBeenCalled()
   })
 
+  it('does not count blank performance-check URLs as requested when the save result is missing', () => {
+    const transport = createTransport()
+    const tracker = createWorkflowAnalytics({
+      createBatchId: () => 'batch-blank-performance-check',
+      getFilesystemSupported: () => true,
+      getNotificationEnabled: () => false,
+      now: () => 320,
+      transport,
+    })
+    const batch = tracker.previewStarted({ urlCount: 1, startedAt: 100 })
+    const notRequestedListing = {
+      ...listing,
+      performanceCheckUrl: '   ',
+    }
+
+    tracker.previewCompleted({
+      batch,
+      items: [{ id: 'listing-1', url: firstUrl, status: 'ready' }],
+    })
+    tracker.saveSettled({
+      items: [{ id: 'listing-1', url: firstUrl, listing: notRequestedListing }],
+      saveMethod: 'directory',
+      savedItemIds: new Set(['listing-1']),
+      saveResultsByItemId: new Map([
+        [
+          'listing-1',
+          createSaveResult({
+            performanceCheckStatus: 'missing',
+            sourceUrl: firstUrl,
+          }),
+        ],
+      ]),
+    })
+
+    expect(transport.trackSaveCompleted).toHaveBeenCalledWith(
+      expect.objectContaining({
+        batchId: 'batch-blank-performance-check',
+        performanceCheckRequestedCount: 0,
+        performanceCheckSavedCount: 0,
+        performanceCheckMissingCount: 0,
+        performanceCheckImageCount: 0,
+      })
+    )
+    expect(transport.trackListingFailed).not.toHaveBeenCalled()
+  })
+
   it('keeps performance-check aggregates separate from vehicle save failures', () => {
     const transport = createTransport()
     const tracker = createWorkflowAnalytics({

--- a/src/v2/application/truck-harvester-workflow/workflow-analytics.test.ts
+++ b/src/v2/application/truck-harvester-workflow/workflow-analytics.test.ts
@@ -185,6 +185,7 @@ describe('workflow analytics adapter', () => {
       ],
       saveMethod: 'directory',
       savedItemIds: new Set(['listing-1']),
+      saveResultsByItemId: new Map(),
     })
 
     expect(transport.trackSaveStarted).toHaveBeenCalledTimes(2)
@@ -258,6 +259,7 @@ describe('workflow analytics adapter', () => {
       items: [item],
       saveMethod: 'directory',
       savedItemIds: new Set(),
+      saveResultsByItemId: new Map(),
     })
 
     tracker.saveStarted({
@@ -268,6 +270,7 @@ describe('workflow analytics adapter', () => {
       items: [item],
       saveMethod: 'directory',
       savedItemIds: new Set([item.id]),
+      saveResultsByItemId: new Map(),
     })
 
     expect(transport.trackSaveFailed).toHaveBeenCalledWith(

--- a/src/v2/application/truck-harvester-workflow/workflow-analytics.ts
+++ b/src/v2/application/truck-harvester-workflow/workflow-analytics.ts
@@ -64,7 +64,7 @@ export interface WorkflowTracker {
     items: readonly WorkflowSaveItem[]
     saveMethod: SaveMethod
     savedItemIds: ReadonlySet<string>
-    saveResultsByItemId?: ReadonlyMap<string, TruckSaveResult>
+    saveResultsByItemId: ReadonlyMap<string, TruckSaveResult>
   }) => void
   removeListing: (id: string) => void
 }

--- a/src/v2/application/truck-harvester-workflow/workflow-analytics.ts
+++ b/src/v2/application/truck-harvester-workflow/workflow-analytics.ts
@@ -1,4 +1,5 @@
 import { type TruckListing } from '@/v2/entities/truck'
+import { type TruckSaveResult } from '@/v2/features/file-management'
 import {
   createAnalyticsBatchId,
   trackBatchStarted,
@@ -63,6 +64,7 @@ export interface WorkflowTracker {
     items: readonly WorkflowSaveItem[]
     saveMethod: SaveMethod
     savedItemIds: ReadonlySet<string>
+    saveResultsByItemId?: ReadonlyMap<string, TruckSaveResult>
   }) => void
   removeListing: (id: string) => void
 }

--- a/src/v2/application/truck-harvester-workflow/workflow-analytics.ts
+++ b/src/v2/application/truck-harvester-workflow/workflow-analytics.ts
@@ -82,6 +82,13 @@ interface SaveBatchGroup {
   items: WorkflowSaveItem[]
 }
 
+interface PerformanceCheckBatchCounts {
+  performanceCheckRequestedCount: number
+  performanceCheckSavedCount: number
+  performanceCheckMissingCount: number
+  performanceCheckImageCount: number
+}
+
 const missingListingIdentityPlaceholder = '차명 정보 없음'
 
 const defaultTransport: WorkflowAnalyticsTransport = {
@@ -135,6 +142,7 @@ export function createWorkflowAnalytics({
     batch: AnalyticsBatchRef,
     items: readonly WorkflowPreviewItem[],
     options: {
+      performanceCheckCounts?: PerformanceCheckBatchCounts
       saveMethod?: SaveMethod
       savedCount?: number
       saveFailedCount?: number
@@ -149,6 +157,14 @@ export function createWorkflowAnalytics({
     previewFailedCount: items.filter((item) => item.status === 'failed').length,
     savedCount: options.savedCount ?? 0,
     saveFailedCount: options.saveFailedCount ?? 0,
+    performanceCheckRequestedCount:
+      options.performanceCheckCounts?.performanceCheckRequestedCount,
+    performanceCheckSavedCount:
+      options.performanceCheckCounts?.performanceCheckSavedCount,
+    performanceCheckMissingCount:
+      options.performanceCheckCounts?.performanceCheckMissingCount,
+    performanceCheckImageCount:
+      options.performanceCheckCounts?.performanceCheckImageCount,
     durationMs: getDuration(now, batch.startedAt),
     saveMethod: options.saveMethod,
     filesystemSupported: getFilesystemSupported(),
@@ -210,6 +226,50 @@ export function createWorkflowAnalytics({
     saveFailedCount: group.items.filter((item) => saveFailureIds.has(item.id))
       .length,
   })
+
+  const hasRequestedPerformanceCheck = (listing: TruckListing) =>
+    Boolean(listing.performanceCheckUrl?.trim())
+
+  const getPerformanceCheckCounts = (
+    group: SaveBatchGroup,
+    saveResultsByItemId: ReadonlyMap<string, TruckSaveResult>
+  ): PerformanceCheckBatchCounts => {
+    let performanceCheckRequestedCount = 0
+    let performanceCheckSavedCount = 0
+    let performanceCheckMissingCount = 0
+    let performanceCheckImageCount = 0
+
+    group.items.forEach((item) => {
+      const requested = hasRequestedPerformanceCheck(item.listing)
+
+      if (requested) {
+        performanceCheckRequestedCount += 1
+      }
+
+      const result = saveResultsByItemId.get(item.id)
+
+      if (!result) {
+        return
+      }
+
+      if (result.performanceCheckStatus === 'saved') {
+        performanceCheckSavedCount += 1
+      }
+
+      if (requested && result.performanceCheckStatus === 'missing') {
+        performanceCheckMissingCount += 1
+      }
+
+      performanceCheckImageCount += result.performanceCheckImageCount
+    })
+
+    return {
+      performanceCheckRequestedCount,
+      performanceCheckSavedCount,
+      performanceCheckMissingCount,
+      performanceCheckImageCount,
+    }
+  }
 
   return {
     unsupportedInputFailed: ({ rawInput, startedAt }) => {
@@ -281,15 +341,20 @@ export function createWorkflowAnalytics({
         elapsedMs: getDuration(now, batch.startedAt),
       })
     },
-    saveSettled: ({ items, saveMethod, savedItemIds }) => {
+    saveSettled: ({ items, saveMethod, savedItemIds, saveResultsByItemId }) => {
       getSaveGroups(items).forEach((group) => {
         const counts = getSaveCounts(group, savedItemIds)
+        const performanceCheckCounts = getPerformanceCheckCounts(
+          group,
+          saveResultsByItemId
+        )
         const input = toBatchInput(
           group.batch,
           toReadyPreviewItems(group.items),
           {
             ...counts,
             saveMethod,
+            performanceCheckCounts,
           }
         )
 

--- a/src/v2/shared/lib/__tests__/analytics.test.ts
+++ b/src/v2/shared/lib/__tests__/analytics.test.ts
@@ -93,6 +93,51 @@ describe('analytics payload builders', () => {
     expect(data).not.toHaveProperty('vehicle_name')
   })
 
+  it('builds batch event data with performance-check aggregates only as counts', () => {
+    const data = toBatchEventData({
+      batchId: 'batch-performance-checks',
+      urlCount: 4,
+      uniqueUrlCount: 4,
+      readyCount: 4,
+      invalidCount: 0,
+      previewFailedCount: 0,
+      savedCount: 4,
+      saveFailedCount: 0,
+      durationMs: 2400,
+      saveMethod: 'zip',
+      filesystemSupported: false,
+      notificationEnabled: true,
+      performanceCheckRequestedCount: 3,
+      performanceCheckSavedCount: 2,
+      performanceCheckMissingCount: 1,
+      performanceCheckImageCount: 5,
+    })
+
+    expect(data).toEqual({
+      batch_id: 'batch-performance-checks',
+      url_count: 4,
+      unique_url_count: 4,
+      ready_count: 4,
+      invalid_count: 0,
+      preview_failed_count: 0,
+      saved_count: 4,
+      save_failed_count: 0,
+      duration_ms: 2400,
+      save_method: 'zip',
+      filesystem_supported: false,
+      notification_enabled: true,
+      performance_check_requested_count: 3,
+      performance_check_saved_count: 2,
+      performance_check_missing_count: 1,
+      performance_check_image_count: 5,
+    })
+    expect(data).not.toHaveProperty('listing_url')
+    expect(data).not.toHaveProperty('vehicle_number')
+    expect(data).not.toHaveProperty('vehicle_name')
+    expect(data).not.toHaveProperty('performance_check_url')
+    expect(data).not.toHaveProperty('checkpaper_url')
+  })
+
   it.each([
     [Number.NaN, 0],
     [Number.POSITIVE_INFINITY, 0],
@@ -310,6 +355,10 @@ describe('analytics tracking', () => {
       saveMethod: 'directory',
       filesystemSupported: true,
       notificationEnabled: false,
+      performanceCheckRequestedCount: 3,
+      performanceCheckSavedCount: 2,
+      performanceCheckMissingCount: 1,
+      performanceCheckImageCount: 4,
     })
 
     expect(track).toHaveBeenCalledWith('save_completed', {
@@ -326,6 +375,10 @@ describe('analytics tracking', () => {
       save_method: 'directory',
       filesystem_supported: true,
       notification_enabled: false,
+      performance_check_requested_count: 3,
+      performance_check_saved_count: 2,
+      performance_check_missing_count: 1,
+      performance_check_image_count: 4,
     })
   })
 

--- a/src/v2/shared/lib/analytics.ts
+++ b/src/v2/shared/lib/analytics.ts
@@ -21,6 +21,10 @@ export interface BatchAnalyticsInput {
   previewFailedCount: number
   savedCount: number
   saveFailedCount: number
+  performanceCheckRequestedCount?: number
+  performanceCheckSavedCount?: number
+  performanceCheckMissingCount?: number
+  performanceCheckImageCount?: number
   durationMs: number
   saveMethod?: SaveMethod
   filesystemSupported: boolean
@@ -115,6 +119,10 @@ export function toBatchEventData(input: BatchAnalyticsInput) {
     preview_failed_count: input.previewFailedCount,
     saved_count: input.savedCount,
     save_failed_count: input.saveFailedCount,
+    performance_check_requested_count: input.performanceCheckRequestedCount,
+    performance_check_saved_count: input.performanceCheckSavedCount,
+    performance_check_missing_count: input.performanceCheckMissingCount,
+    performance_check_image_count: input.performanceCheckImageCount,
     duration_ms: durationMs,
     save_method: input.saveMethod,
     filesystem_supported: input.filesystemSupported,


### PR DESCRIPTION
## Summary
- Add aggregate performance-check fields to batch save analytics payloads.
- Thread `TruckSaveResult` values from save workflow into workflow analytics via `saveResultsByItemId`.
- Count requested, saved, missing, and saved image totals without treating missing performance-check records as vehicle save failures.

## Impact
- Successful and batch-level failed save events can now report performance-check save quality as counts only.
- Raw CheckPaper URLs, per-vehicle performance-check URLs, document contents, and image bytes are not sent.
- UI, renderer, folder layout, file-system behavior, and ZIP structure are unchanged.

## Validation
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run test -- --run` (51 files, 377 tests)
- `bun run build` (rerun with escalation because sandboxed Turbopack build could not bind its internal worker port)