### PR TITLE
Add maintainer automation

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,84 @@
+'area:ci':
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/**'
+
+'area:docs':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'docs/**'
+          - 'memo/**'
+          - 'README.md'
+          - 'CLAUDE.md'
+          - 'AGENTS.md'
+
+'area:api':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/app/api/**'
+
+'area:v2-workflow':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/v2/application/**'
+
+'area:parsing':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/v2/shared/lib/**'
+          - 'src/v2/features/truck-processing/**'
+          - 'src/v2/features/listing-preparation/**'
+          - 'src/v2/entities/**'
+
+'area:rendering':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/**/carmodoo*'
+          - 'src/**/checkpaper*'
+          - 'src/**/renderer*'
+          - 'e2e/carmodoo-*.spec.ts'
+          - 'e2e/*render*.spec.ts'
+
+'area:analytics':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/**/analytics*'
+          - 'src/v2/application/**/workflow-analytics*'
+
+'area:e2e':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'e2e/**'
+
+'area:tests':
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*.test.ts'
+          - '**/*.test.tsx'
+          - '**/__tests__/**'
+
+'area:package':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'package.json'
+          - 'bun.lock'
+          - 'next.config.*'
+          - 'tsconfig.json'
+
+'type:feature':
+  - head-branch:
+      - '^feat[/-]'
+      - '^feature[/-]'
+
+'type:fix':
+  - head-branch:
+      - '^fix[/-]'
+      - '^hotfix[/-]'
+
+'type:docs':
+  - head-branch:
+      - '^docs[/-]'
+
+'target:main':
+  - base-branch:
+      - '^main$'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -25,7 +25,9 @@
 'area:parsing':
   - changed-files:
       - any-glob-to-any-file:
-          - 'src/v2/shared/lib/**'
+          - 'src/v2/shared/lib/parse-*.ts'
+          - 'src/v2/shared/lib/checkpaper-proxy.ts'
+          - 'src/v2/features/listing-preparation/model/*parser*.ts'
           - 'src/v2/features/truck-processing/**'
           - 'src/v2/features/listing-preparation/**'
           - 'src/v2/entities/**'
@@ -34,8 +36,11 @@
   - changed-files:
       - any-glob-to-any-file:
           - 'src/**/carmodoo*'
+          - 'src/**/carmodoo*/**'
           - 'src/**/checkpaper*'
+          - 'src/**/checkpaper*/**'
           - 'src/**/renderer*'
+          - 'src/**/renderer*/**'
           - 'e2e/carmodoo-*.spec.ts'
           - 'e2e/*render*.spec.ts'
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,24 @@
+name: Label PRs
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  label:
+    name: Label
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply labels
+        uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
+        with:
+          sync-labels: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   issues: write
-  pull-requests: write
 
 jobs:
   stale:
@@ -18,16 +17,14 @@ jobs:
         uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         with:
           stale-issue-label: 'status:stale'
-          stale-pr-label: 'status:stale'
           days-before-issue-stale: 90
           days-before-issue-close: -1
           days-before-pr-stale: -1
           days-before-pr-close: -1
+          remove-pr-stale-when-updated: false
           stale-issue-message: >-
             이 이슈는 90일 동안 활동이 없어 stale로 표시합니다.
             아직 필요하면 댓글을 남기거나 `status:stale` 라벨을 제거해 주세요.
           exempt-issue-labels: >-
-            security,pinned,in-progress,needs-decision,customer-critical,preview-investigation,deployment-investigation
-          exempt-pr-labels: >-
             security,pinned,in-progress,needs-decision,customer-critical,preview-investigation,deployment-investigation
           operations-per-run: 50

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,33 @@
+name: Mark Stale Issues
+
+on:
+  schedule:
+    - cron: '17 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    name: Mark stale issues
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark inactive issues
+        uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
+        with:
+          stale-issue-label: 'status:stale'
+          stale-pr-label: 'status:stale'
+          days-before-issue-stale: 90
+          days-before-issue-close: -1
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          stale-issue-message: >-
+            이 이슈는 90일 동안 활동이 없어 stale로 표시합니다.
+            아직 필요하면 댓글을 남기거나 `status:stale` 라벨을 제거해 주세요.
+          exempt-issue-labels: >-
+            security,pinned,in-progress,needs-decision,customer-critical,preview-investigation,deployment-investigation
+          exempt-pr-labels: >-
+            security,pinned,in-progress,needs-decision,customer-critical,preview-investigation,deployment-investigation
+          operations-per-run: 50

--- a/docs/superpowers/plans/2026-06-26-maintainer-automation.md
+++ b/docs/superpowers/plans/2026-06-26-maintainer-automation.md
@@ -95,7 +95,9 @@ Create `/Users/jaemin/programming/projects/archive/truck-harvester/.github/label
 'area:parsing':
   - changed-files:
       - any-glob-to-any-file:
-          - 'src/v2/shared/lib/**'
+          - 'src/v2/shared/lib/parse-*.ts'
+          - 'src/v2/shared/lib/checkpaper-proxy.ts'
+          - 'src/v2/features/listing-preparation/model/*parser*.ts'
           - 'src/v2/features/truck-processing/**'
           - 'src/v2/features/listing-preparation/**'
           - 'src/v2/entities/**'
@@ -104,8 +106,11 @@ Create `/Users/jaemin/programming/projects/archive/truck-harvester/.github/label
   - changed-files:
       - any-glob-to-any-file:
           - 'src/**/carmodoo*'
+          - 'src/**/carmodoo*/**'
           - 'src/**/checkpaper*'
+          - 'src/**/checkpaper*/**'
           - 'src/**/renderer*'
+          - 'src/**/renderer*/**'
           - 'e2e/carmodoo-*.spec.ts'
           - 'e2e/*render*.spec.ts'
 

--- a/docs/superpowers/plans/2026-06-26-maintainer-automation.md
+++ b/docs/superpowers/plans/2026-06-26-maintainer-automation.md
@@ -47,6 +47,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
   pull-requests: write
 
 jobs:
@@ -60,7 +61,7 @@ jobs:
           sync-labels: true
 ```
 
-Expected: The workflow never checks out the repository and only changes PR labels.
+Expected: The workflow never checks out the repository and only changes PR labels. `issues: write` allows `actions/labeler` to create missing configured labels on first run.
 
 - [ ] **Step 2: Add the labeler config**
 

--- a/docs/superpowers/plans/2026-06-26-maintainer-automation.md
+++ b/docs/superpowers/plans/2026-06-26-maintainer-automation.md
@@ -19,7 +19,7 @@ Create or modify these files inside `/Users/jaemin/programming/projects/archive/
 - Create: `.github/labeler.yml`
   - Responsibility: Define file and branch matching rules for API, parser, renderer, analytics, docs, test, and CI labels.
 - Create: `.github/workflows/stale.yml`
-  - Responsibility: Mark inactive issues stale without closing issues or PRs automatically.
+  - Responsibility: Mark inactive issues stale without closing issues or mutating PRs automatically.
 - Preserve: `.github/workflows/ci.yml`
   - Responsibility: Continue running the existing Bun install, typecheck, lint, format, tests, Carmodoo smoke, and build flow.
 
@@ -213,7 +213,6 @@ on:
 
 permissions:
   issues: write
-  pull-requests: write
 
 jobs:
   stale:
@@ -224,22 +223,20 @@ jobs:
         uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         with:
           stale-issue-label: 'status:stale'
-          stale-pr-label: 'status:stale'
           days-before-issue-stale: 90
           days-before-issue-close: -1
           days-before-pr-stale: -1
           days-before-pr-close: -1
+          remove-pr-stale-when-updated: false
           stale-issue-message: >-
             이 이슈는 90일 동안 활동이 없어 stale로 표시합니다.
             아직 필요하면 댓글을 남기거나 `status:stale` 라벨을 제거해 주세요.
           exempt-issue-labels: >-
             security,pinned,in-progress,needs-decision,customer-critical,preview-investigation,deployment-investigation
-          exempt-pr-labels: >-
-            security,pinned,in-progress,needs-decision,customer-critical,preview-investigation,deployment-investigation
           operations-per-run: 50
 ```
 
-Expected: The workflow marks inactive issues stale after 90 days, never closes issues, and never marks or closes PRs automatically.
+Expected: The workflow marks inactive issues stale after 90 days, never closes issues, and never marks, closes, or removes stale labels from PRs.
 
 - [ ] **Step 2: Validate stale workflow syntax**
 
@@ -259,7 +256,7 @@ Run:
 sed -n '1,120p' .github/workflows/stale.yml
 ```
 
-Expected: The file shows only `issues: write` and `pull-requests: write`; it does not include `contents: write` or secrets.
+Expected: The file shows only `issues: write`; it does not include `pull-requests: write`, `contents: write`, or secrets.
 
 - [ ] **Step 4: Commit stale automation**
 
@@ -276,6 +273,6 @@ Expected: One commit contains only the stale workflow.
 
 - [ ] Existing `.github/workflows/ci.yml` remains unchanged.
 - [ ] Labeler uses `pull_request_target` without checkout or code execution.
-- [ ] Stale marks issues only and never auto-closes issues or PRs.
+- [ ] Stale marks issues only and never auto-closes issues or mutates PRs.
 - [ ] Release Drafter and PR comment automation are not included in this first implementation.
 - [ ] All third-party actions are pinned to full commit SHA.

--- a/docs/superpowers/plans/2026-06-26-maintainer-automation.md
+++ b/docs/superpowers/plans/2026-06-26-maintainer-automation.md
@@ -1,0 +1,275 @@
+# Maintainer Automation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add PR label automation and conservative issue stale marking for `truck-harvester` while preserving the existing Bun/Playwright CI workflow.
+
+**Architecture:** Add one label-only `pull_request_target` workflow, one `.github/labeler.yml`, and one scheduled stale workflow. The plan does not modify the existing `ci.yml`, does not add Release Drafter, and does not add PR comments until a concrete repeated checklist proves useful.
+
+**Tech Stack:** GitHub Actions, actions/labeler pinned to `v6.1.0`, actions/stale pinned to `v10.3.0`, existing Bun/Next.js/Playwright CI.
+
+---
+
+## File Structure
+
+Create or modify these files inside `/Users/jaemin/programming/projects/archive/truck-harvester`.
+
+- Create: `.github/workflows/labeler.yml`
+  - Responsibility: Apply PR labels without checking out or executing PR code.
+- Create: `.github/labeler.yml`
+  - Responsibility: Define file and branch matching rules for API, parser, renderer, analytics, docs, test, and CI labels.
+- Create: `.github/workflows/stale.yml`
+  - Responsibility: Mark inactive issues stale without closing issues or PRs automatically.
+- Preserve: `.github/workflows/ci.yml`
+  - Responsibility: Continue running the existing Bun install, typecheck, lint, format, tests, Carmodoo smoke, and build flow.
+
+## Task 1: Add PR Labeler
+
+**Files:**
+
+- Create: `/Users/jaemin/programming/projects/archive/truck-harvester/.github/workflows/labeler.yml`
+- Create: `/Users/jaemin/programming/projects/archive/truck-harvester/.github/labeler.yml`
+
+- [ ] **Step 1: Add the labeler workflow**
+
+Create `/Users/jaemin/programming/projects/archive/truck-harvester/.github/workflows/labeler.yml`:
+
+```yaml
+name: Label PRs
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    name: Label
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply labels
+        uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
+        with:
+          sync-labels: true
+```
+
+Expected: The workflow never checks out the repository and only changes PR labels.
+
+- [ ] **Step 2: Add the labeler config**
+
+Create `/Users/jaemin/programming/projects/archive/truck-harvester/.github/labeler.yml`:
+
+```yaml
+'area:ci':
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/**'
+
+'area:docs':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'docs/**'
+          - 'memo/**'
+          - 'README.md'
+          - 'CLAUDE.md'
+          - 'AGENTS.md'
+
+'area:api':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/app/api/**'
+
+'area:v2-workflow':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/v2/application/**'
+
+'area:parsing':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/v2/shared/lib/**'
+          - 'src/v2/features/truck-processing/**'
+          - 'src/v2/features/listing-preparation/**'
+          - 'src/v2/entities/**'
+
+'area:rendering':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/**/carmodoo*'
+          - 'src/**/checkpaper*'
+          - 'src/**/renderer*'
+          - 'e2e/carmodoo-*.spec.ts'
+          - 'e2e/*render*.spec.ts'
+
+'area:analytics':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/**/analytics*'
+          - 'src/v2/application/**/workflow-analytics*'
+
+'area:e2e':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'e2e/**'
+
+'area:tests':
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*.test.ts'
+          - '**/*.test.tsx'
+          - '**/__tests__/**'
+
+'area:package':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'package.json'
+          - 'bun.lock'
+          - 'next.config.*'
+          - 'tsconfig.json'
+
+'type:feature':
+  - head-branch:
+      - '^feat[/-]'
+      - '^feature[/-]'
+
+'type:fix':
+  - head-branch:
+      - '^fix[/-]'
+      - '^hotfix[/-]'
+
+'type:docs':
+  - head-branch:
+      - '^docs[/-]'
+
+'status:needs-review':
+  - base-branch:
+      - '^main$'
+```
+
+Expected: The config labels API, parser, renderer, analytics, e2e, docs, package, test, and CI work without catch-all labels.
+
+- [ ] **Step 3: Validate labeler files**
+
+Run:
+
+```bash
+actionlint .github/workflows/labeler.yml
+ruby -e 'require "yaml"; YAML.load_file(".github/labeler.yml"); puts "labeler config ok"'
+```
+
+Expected: `actionlint` prints no output, and Ruby prints `labeler config ok`.
+
+- [ ] **Step 4: Confirm existing CI workflow is unchanged**
+
+Run:
+
+```bash
+git diff -- .github/workflows/ci.yml
+```
+
+Expected: No output.
+
+- [ ] **Step 5: Commit labeler automation**
+
+Run:
+
+```bash
+git add .github/workflows/labeler.yml .github/labeler.yml docs/superpowers/plans/2026-06-26-maintainer-automation.md
+git commit -m "ci: add pull request labeler"
+```
+
+Expected: One commit contains labeler files and this plan file; existing CI remains unchanged.
+
+## Task 2: Add Conservative Issue Stale Marking
+
+**Files:**
+
+- Create: `/Users/jaemin/programming/projects/archive/truck-harvester/.github/workflows/stale.yml`
+
+- [ ] **Step 1: Add the stale workflow**
+
+Create `/Users/jaemin/programming/projects/archive/truck-harvester/.github/workflows/stale.yml`:
+
+```yaml
+name: Mark Stale Issues
+
+on:
+  schedule:
+    - cron: '17 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    name: Mark stale issues
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark inactive issues
+        uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
+        with:
+          stale-issue-label: 'status:stale'
+          stale-pr-label: 'status:stale'
+          days-before-issue-stale: 90
+          days-before-issue-close: -1
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          stale-issue-message: >-
+            이 이슈는 90일 동안 활동이 없어 stale로 표시합니다.
+            아직 필요하면 댓글을 남기거나 `status:stale` 라벨을 제거해 주세요.
+          exempt-issue-labels: >-
+            security,pinned,in-progress,needs-decision,customer-critical,preview-investigation,deployment-investigation
+          exempt-pr-labels: >-
+            security,pinned,in-progress,needs-decision,customer-critical,preview-investigation,deployment-investigation
+          operations-per-run: 50
+```
+
+Expected: The workflow marks inactive issues stale after 90 days, never closes issues, and never marks or closes PRs automatically.
+
+- [ ] **Step 2: Validate stale workflow syntax**
+
+Run:
+
+```bash
+actionlint .github/workflows/stale.yml
+```
+
+Expected: No output and exit code `0`.
+
+- [ ] **Step 3: Review stale workflow permissions**
+
+Run:
+
+```bash
+sed -n '1,120p' .github/workflows/stale.yml
+```
+
+Expected: The file shows only `issues: write` and `pull-requests: write`; it does not include `contents: write` or secrets.
+
+- [ ] **Step 4: Commit stale automation**
+
+Run:
+
+```bash
+git add .github/workflows/stale.yml
+git commit -m "ci: add stale issue marking"
+```
+
+Expected: One commit contains only the stale workflow.
+
+## Self-Review Checklist
+
+- [ ] Existing `.github/workflows/ci.yml` remains unchanged.
+- [ ] Labeler uses `pull_request_target` without checkout or code execution.
+- [ ] Stale marks issues only and never auto-closes issues or PRs.
+- [ ] Release Drafter and PR comment automation are not included in this first implementation.
+- [ ] All third-party actions are pinned to full commit SHA.

--- a/docs/superpowers/plans/2026-06-26-maintainer-automation.md
+++ b/docs/superpowers/plans/2026-06-26-maintainer-automation.md
@@ -148,7 +148,7 @@ Create `/Users/jaemin/programming/projects/archive/truck-harvester/.github/label
   - head-branch:
       - '^docs[/-]'
 
-'status:needs-review':
+'target:main':
   - base-branch:
       - '^main$'
 ```

--- a/docs/superpowers/plans/2026-06-26-maintainer-automation.md
+++ b/docs/superpowers/plans/2026-06-26-maintainer-automation.md
@@ -236,7 +236,7 @@ jobs:
           operations-per-run: 50
 ```
 
-Expected: The workflow marks inactive issues stale after 90 days, never closes issues, and never marks, closes, or removes stale labels from PRs.
+Expected: The workflow marks inactive issues stale after 90 days, never closes issues, and never marks, closes, or removes stale labels from PRs. The remote `status:stale` label must exist before this workflow runs because `actions/stale` does not create missing labels.
 
 - [ ] **Step 2: Validate stale workflow syntax**
 
@@ -274,5 +274,6 @@ Expected: One commit contains only the stale workflow.
 - [ ] Existing `.github/workflows/ci.yml` remains unchanged.
 - [ ] Labeler uses `pull_request_target` without checkout or code execution.
 - [ ] Stale marks issues only and never auto-closes issues or mutates PRs.
+- [ ] The remote `status:stale` label exists before the stale workflow is enabled.
 - [ ] Release Drafter and PR comment automation are not included in this first implementation.
 - [ ] All third-party actions are pinned to full commit SHA.

--- a/docs/superpowers/specs/2026-06-26-maintainer-automation-design.md
+++ b/docs/superpowers/specs/2026-06-26-maintainer-automation-design.md
@@ -47,7 +47,7 @@ The latest tags below were verified from live GitHub tag refs on 2026-06-26 KST.
 
 ## Error Handling
 
-- Labeler failures caused by fork permissions should be handled by the label-only `pull_request_target` design, not by widening token permissions beyond `pull-requests: write` and `contents: read`.
+- Labeler failures caused by fork permissions should be handled by the label-only `pull_request_target` design with no checkout or shell execution. Include `issues: write` only so `actions/labeler` can create missing configured labels on first run.
 - Stale automation must exempt `security`, `pinned`, `in-progress`, `needs-decision`, and release-critical work.
 - Comment automation must update an existing bot comment by marker; duplicate comments are considered a design failure.
 - If a workflow begins producing noisy labels or stale events, the rollback is to disable the single new workflow file rather than touching build or release jobs.

--- a/docs/superpowers/specs/2026-06-26-maintainer-automation-design.md
+++ b/docs/superpowers/specs/2026-06-26-maintainer-automation-design.md
@@ -18,7 +18,7 @@ Common rules:
 - Use a consistent label taxonomy: `area:*`, `type:*`, `scope:*`, and `status:*`.
 - Add `actions/labeler` for PR triage based on file paths and branch names.
 - Run label/comment workflows with `pull_request_target` only when they do not checkout or execute untrusted PR code.
-- Apply stale handling conservatively, starting with issues and avoiding automatic PR closure unless explicitly enabled later.
+- Apply stale handling conservatively, starting with issues and avoiding PR mutation unless explicitly enabled later.
 - Use `peter-evans/create-or-update-comment` only when a stable marker prevents duplicate bot comments.
 - Prefer repository-native validation scripts over broad Super-Linter defaults.
 - Preserve existing release/deploy workflows unless the repository-specific section explicitly says otherwise.
@@ -73,7 +73,7 @@ Add conservative Stale:
 
 - Issue-only stale behavior after a longer inactivity window.
 - Exempt `security`, `pinned`, `in-progress`, `needs-decision`, `customer-critical`, and preview/deployment investigation labels.
-- Do not auto-close PRs.
+- Do not mutate or auto-close PRs.
 
 Add a low-noise PR comment only if it stays useful:
 

--- a/docs/superpowers/specs/2026-06-26-maintainer-automation-design.md
+++ b/docs/superpowers/specs/2026-06-26-maintainer-automation-design.md
@@ -1,0 +1,94 @@
+# Maintainer Automation Design
+
+Date: 2026-06-26
+
+## Shared Baseline
+
+This project is part of a four-repository maintainer automation rollout covering:
+
+- `synchronize-tab-scrolling`
+- `truck-harvester`
+- `eslint-config`
+- `bendd`
+
+The rollout uses a common maintainer baseline with repository-specific exceptions. The baseline automates repetitive triage without replacing the repository's existing release, build, or deployment contract.
+
+Common rules:
+
+- Use a consistent label taxonomy: `area:*`, `type:*`, `scope:*`, and `status:*`.
+- Add `actions/labeler` for PR triage based on file paths and branch names.
+- Run label/comment workflows with `pull_request_target` only when they do not checkout or execute untrusted PR code.
+- Apply stale handling conservatively, starting with issues and avoiding automatic PR closure unless explicitly enabled later.
+- Use `peter-evans/create-or-update-comment` only when a stable marker prevents duplicate bot comments.
+- Prefer repository-native validation scripts over broad Super-Linter defaults.
+- Preserve existing release/deploy workflows unless the repository-specific section explicitly says otherwise.
+
+## Latest Action Versions
+
+The latest tags below were verified from live GitHub tag refs on 2026-06-26 KST. Implementation should use these versions or newer if re-verified, and should pin third-party actions to the full tag SHA rather than floating version tags.
+
+| Action                                 | Latest tag verified on 2026-06-26 KST | Tag SHA to pin during implementation       |
+| -------------------------------------- | ------------------------------------- | ------------------------------------------ |
+| `actions/labeler`                      | `v6.1.0`                              | `f27b608878404679385c85cfa523b85ccb86e213` |
+| `actions/stale`                        | `v10.3.0`                             | `eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899` |
+| `release-drafter/release-drafter`      | `v7.5.1`                              | `3832cfb52f98ab0f0e5b62aecf94909e334d4da6` |
+| `peter-evans/create-or-update-comment` | `v5.0.0`                              | `e8674b075228eee787fea43ef493e45ece1004c9` |
+| `actions/checkout`                     | `v7.0.0`                              | `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0` |
+| `actions/setup-node`                   | `v6.4.0`                              | `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` |
+| `pnpm/action-setup`                    | `v6.0.9`                              | `008330803749db0355799c700092d9a85fd074e9` |
+| `oven-sh/setup-bun`                    | `v2.2.0`                              | `0c5077e51419868618aeaa5fe8019c62421857d6` |
+
+## Security Requirements
+
+- Every workflow must declare minimal `permissions`.
+- `pull_request_target` workflows may label or comment, but must not checkout, build, test, or run code from the pull request branch.
+- Third-party actions must be pinned to full commit SHA in the implementation plan.
+- Secret-bearing release or deploy workflows are out of scope unless the repository already has them and this design explicitly preserves them.
+
+## Error Handling
+
+- Labeler failures caused by fork permissions should be handled by the label-only `pull_request_target` design, not by widening token permissions beyond `pull-requests: write` and `contents: read`.
+- Stale automation must exempt `security`, `pinned`, `in-progress`, `needs-decision`, and release-critical work.
+- Comment automation must update an existing bot comment by marker; duplicate comments are considered a design failure.
+- If a workflow begins producing noisy labels or stale events, the rollback is to disable the single new workflow file rather than touching build or release jobs.
+
+## Repository Context
+
+`truck-harvester` is a Next.js application with a live Vercel deployment and a strong existing CI workflow. CI already runs Bun install, typecheck, lint, format check, unit tests, a Carmodoo render glyph smoke test, and build. Recent work involved protected Vercel preview behavior, Playwright, native Chromium rendering, and analytics, so PR context and ownership labels are more useful than another generic linter.
+
+## Proposed Automation
+
+Add Labeler:
+
+- `area:api` for `src/app/api/**`.
+- `area:v2-workflow` for `src/v2/application/**`.
+- `area:parsing` for parser/provider paths such as `src/v2/shared/lib/**` and truck-processing features.
+- `area:rendering` for Carmodoo, CheckPaper, Playwright renderer, or font/glyph-related paths.
+- `area:analytics` for workflow analytics and Umami-related paths.
+- `area:e2e` for `e2e/**`.
+- `area:docs` for `docs/**`, `memo/**`, and README changes.
+- `area:ci` for `.github/**`.
+
+Add conservative Stale:
+
+- Issue-only stale behavior after a longer inactivity window.
+- Exempt `security`, `pinned`, `in-progress`, `needs-decision`, `customer-critical`, and preview/deployment investigation labels.
+- Do not auto-close PRs.
+
+Add a low-noise PR comment only if it stays useful:
+
+- Use `peter-evans/create-or-update-comment@v5.0.0`, pinned to `e8674b075228eee787fea43ef493e45ece1004c9` during implementation.
+- Comment content should be a short verification checklist for preview-sensitive changes, not a duplicate of CI logs.
+- Use a stable marker so repeated workflow runs update the same comment.
+
+## Explicit Non-Goals
+
+- Do not add Release Drafter until this project adopts explicit product release tagging.
+- Do not add Super-Linter; existing CI is broader and better tailored.
+- Do not alter the existing `ci.yml` verification contract in this phase.
+
+## Testing Plan
+
+- Validate new workflow/config YAML separately from the existing CI workflow.
+- Run existing CI-equivalent commands only if implementation touches workflow behavior beyond label/stale/comment files.
+- Confirm PR comment automation does not run untrusted PR code under `pull_request_target`.

--- a/docs/superpowers/specs/2026-06-26-maintainer-automation-design.md
+++ b/docs/superpowers/specs/2026-06-26-maintainer-automation-design.md
@@ -62,7 +62,7 @@ Add Labeler:
 
 - `area:api` for `src/app/api/**`.
 - `area:v2-workflow` for `src/v2/application/**`.
-- `area:parsing` for parser/provider paths such as `src/v2/shared/lib/**` and truck-processing features.
+- `area:parsing` for parser/provider paths such as `parse-*`, `checkpaper-proxy`, listing-preparation parsers, and truck-processing features.
 - `area:rendering` for Carmodoo, CheckPaper, Playwright renderer, or font/glyph-related paths.
 - `area:analytics` for workflow analytics and Umami-related paths.
 - `area:e2e` for `e2e/**`.

--- a/docs/superpowers/specs/2026-06-26-maintainer-automation-design.md
+++ b/docs/superpowers/specs/2026-06-26-maintainer-automation-design.md
@@ -72,6 +72,7 @@ Add Labeler:
 Add conservative Stale:
 
 - Issue-only stale behavior after a longer inactivity window.
+- Ensure the remote `status:stale` label exists because `actions/stale` does not create missing labels.
 - Exempt `security`, `pinned`, `in-progress`, `needs-decision`, `customer-critical`, and preview/deployment investigation labels.
 - Do not mutate or auto-close PRs.
 


### PR DESCRIPTION
## Summary
- Add a pull_request_target labeler workflow with pinned actions and constrained permissions.
- Add path-based labels for v2 workflow, parsing, rendering, entities, infrastructure, tests, and docs.
- Add stale issue marking for inactive issues without mutating pull requests or closing issues automatically.

## Test Plan
- ruby YAML parse for .github/workflows/labeler.yml, .github/labeler.yml, .github/workflows/stale.yml
- forbidden-pattern scan for checkout/run/secrets in labeler workflow
- forbidden-pattern scan for PR mutation and write-expanded permissions in stale workflow
- verified remote label status:stale exists